### PR TITLE
datepicker now shows on top of dialogs

### DIFF
--- a/Purchasing.Web/Css/Site.css
+++ b/Purchasing.Web/Css/Site.css
@@ -597,7 +597,6 @@ h1, h2, h3, h4
 div#ui-datepicker-div.ui-datepicker
 {
     background:#eee;
-    z-index: 500 !important;
 }
 
 #ui-datepicker-div .ui-state-highlight, 


### PR DESCRIPTION
small change so the datepicker can show on top of dialogs.  There was a z-index: 500!important inside the site.css which was putting it behind dialogs (z-index over 1,000).  @feesh if there isn't any need for the 500!important then we can merge this fix.
