### PR TITLE
DB Change Added IsExternal to Approval

### DIFF
--- a/Purchasing.Core/Domain/Approval.cs
+++ b/Purchasing.Core/Domain/Approval.cs
@@ -26,6 +26,8 @@ namespace Purchasing.Core.Domain
 
         public virtual Split Split { get; set; }
 
+        public virtual bool IsExternal { get; set; }
+
         public static List<Approval> FilterUnique(List<Approval> source)
         {
             return source.Distinct(new ApprovalEqualityComparer()).ToList();
@@ -39,6 +41,7 @@ namespace Purchasing.Core.Domain
             Id(x => x.Id);
 
             Map(x => x.Completed);
+            Map(x => x.IsExternal);
 
             References(x => x.User);
             References(x => x.SecondaryUser).Column("SecondaryUserId");

--- a/Purchasing.Web/Services/OrderService.cs
+++ b/Purchasing.Web/Services/OrderService.cs
@@ -654,7 +654,8 @@ namespace Purchasing.Web.Services
                                             Completed = false,
                                             User = approvalInfo.AcctManager,
                                             StatusCode =
-                                                _repositoryFactory.OrderStatusCodeRepository.GetById(OrderStatusCode.Codes.AccountManager)
+                                                _repositoryFactory.OrderStatusCodeRepository.GetById(OrderStatusCode.Codes.AccountManager),
+                                                IsExternal = approvalInfo.IsExternal
                                         },
                                     new Approval
                                         {

--- a/Purchasing.Web/Services/WorkgroupService.cs
+++ b/Purchasing.Web/Services/WorkgroupService.cs
@@ -502,7 +502,7 @@ namespace Purchasing.Web.Services
         }
 
         /// <summary>
-        /// When a 
+        /// When a user is removed from a workgroup, remove them from any pending approvals (note, this does not apply to external approvals)
         /// </summary>
         /// <param name="workgroupPermission"></param>
         public void RemoveUserFromPendingApprovals(WorkgroupPermission workgroupPermission)
@@ -518,7 +518,7 @@ namespace Purchasing.Web.Services
 
             var user = workgroupPermission.User;
             var workgroup = workgroupPermission.Workgroup;
-            var approvals = _repositoryFactory.ApprovalRepository.Queryable.Where(a => !a.Completed && a.User == user && a.Order.Workgroup == workgroup && a.StatusCode.Id == workgroupPermission.Role.Id);
+            var approvals = _repositoryFactory.ApprovalRepository.Queryable.Where(a => !a.Completed && a.User == user && a.Order.Workgroup == workgroup && a.StatusCode.Id == workgroupPermission.Role.Id && !a.IsExternal);
             foreach (var approval in approvals)
             {
                 approval.User = null;

--- a/PurchasingTP.AzureDb/dbo/Tables/Approvals.sql
+++ b/PurchasingTP.AzureDb/dbo/Tables/Approvals.sql
@@ -6,6 +6,7 @@
     [OrderStatusCodeId] CHAR (2)     NOT NULL,
     [OrderId]           INT          NOT NULL,
     [SplitId]           INT          NULL,
+    [IsExternal] BIT NOT NULL DEFAULT ((0)), 
     PRIMARY KEY CLUSTERED ([Id] ASC),
     CONSTRAINT [FK_Approvals_OrderStatusCodes] FOREIGN KEY ([OrderStatusCodeId]) REFERENCES [dbo].[OrderStatusCodes] ([Id]),
     CONSTRAINT [FK_Approvals_Splits] FOREIGN KEY ([SplitId]) REFERENCES [dbo].[Splits] ([Id])


### PR DESCRIPTION
When we remove a person from a workgroup, we also clear out any approvals they were assigned to. We should not be doing this if it was an external account.
