### PR TITLE
set the max clause before querying search indexes

### DIFF
--- a/Purchasing.Web/Services/IndexSearchService.cs
+++ b/Purchasing.Web/Services/IndexSearchService.cs
@@ -258,7 +258,10 @@ namespace Purchasing.Web.Services
             {   
                 var orderIds = filteredOrderIds as int[] ?? filteredOrderIds.ToArray();
 
-                BooleanQuery.MaxClauseCount = orderIds.Length + 1;
+                if (BooleanQuery.MaxClauseCount < orderIds.Length)
+                {
+                    BooleanQuery.MaxClauseCount = orderIds.Length + 1;
+                }
 
                 Query accessQuery = new QueryParser(Version.LUCENE_30, "orderid", analyzer).Parse(string.Join(" ", orderIds));
                 var termsQuery =

--- a/Purchasing.Web/Services/IndexService.cs
+++ b/Purchasing.Web/Services/IndexService.cs
@@ -46,8 +46,7 @@ namespace Purchasing.Web.Services
         private readonly IDbService _dbService;
         private string _indexRoot;
         private readonly Dictionary<Indexes, IndexReader> _indexReaders = new Dictionary<Indexes, IndexReader>();
-        private const int MaxClauseCount = 1024;
-
+        
         public IndexService(IDbService dbService)
         {
             _dbService = dbService;
@@ -201,8 +200,8 @@ namespace Purchasing.Web.Services
 
             var distinctOrderIds = orderids.Distinct().ToArray();
 
-            if (distinctOrderIds.Count() > MaxClauseCount)
-                //If number of distinct orders ids is >default limit, up the limit as necessary
+            if (BooleanQuery.MaxClauseCount < distinctOrderIds.Length)
+            //If number of distinct orders ids is > limit, up the limit as necessary
             {
                 BooleanQuery.MaxClauseCount = distinctOrderIds.Count() + 1;
             }


### PR DESCRIPTION
previously the clause was pulled from the last order history search.

@jSylvestre we can take a look at this next week -- hopefully this will fix the search problem
