### PR TITLE
There was an order where the order status was Conditional approval. The ...

### DIFF
--- a/Purchasing.Mvc/Services/OrderService.cs
+++ b/Purchasing.Mvc/Services/OrderService.cs
@@ -430,7 +430,7 @@ namespace Purchasing.Mvc.Services
             var didApprovalHappen = false;
             var currentApprovalLevel = order.StatusCode.Level;
 
-            var hasWorkgroupRole = _securityService.hasWorkgroupRole(order.StatusCode.Id, order.Workgroup.Id);
+            var hasWorkgroupRole = _securityService.hasWorkgroupRole(order.StatusCode.Id == OrderStatusCode.Codes.ConditionalApprover ? OrderStatusCode.Codes.Approver : order.StatusCode.Id, order.Workgroup.Id);
 
             //If the approval is at the current level & directly associated with the user (primary or secondary), go ahead and approve it
             foreach (var approvalForUserDirectly in


### PR DESCRIPTION
...Conditional approver approved it. The Approver was null in the approvals so it should have defaulted to anyone in that role in the workgroup, but the security service was checking for CA instead of AP (Or, the level 2 which both CA and AP are).
