### PR TITLE
Workaround for inactive Users

### DIFF
--- a/Purchasing.Mvc/Models/WorgroupPeopleListModel.cs
+++ b/Purchasing.Mvc/Models/WorgroupPeopleListModel.cs
@@ -36,7 +36,7 @@ namespace Purchasing.Mvc.Models
                                 };
 
             var allWorkgroupPermissions =
-                workgroupPermissionRepository.Queryable.Where(a => a.Workgroup == workgroup && a.User.IsActive && !a.Role.IsAdmin && !a.IsAdmin);
+                workgroupPermissionRepository.Queryable.Where(a => a.Workgroup == workgroup && !a.Role.IsAdmin && !a.IsAdmin);
 
 
             var workgroupPermissions = !string.IsNullOrWhiteSpace(rolefilter) ? allWorkgroupPermissions.Where(a => a.Role.Id == rolefilter) : allWorkgroupPermissions;

--- a/Purchasing.Mvc/Views/Report/Permissions.cshtml
+++ b/Purchasing.Mvc/Views/Report/Permissions.cshtml
@@ -80,7 +80,13 @@
                         <ul>
                             @foreach (var person in people)
                             {
-                                <li>@(string.Format("{0} {1}", person.User.FullName, person.IsAdmin ? "*" : string.Empty))</li>    
+                                <li>
+                                    @(string.Format("{0} {1}", person.User.FullName, person.IsAdmin ? "*" : string.Empty))
+                                    @if (!person.User.IsActive)
+                                    {
+                                        <span strong style="background-color: lightcoral;">User no longer Active (Probably left the university) They should be removed.</span>
+                                    }
+                                </li>
                             }
                         </ul>    
                     }
@@ -97,7 +103,7 @@
         
             <section class="display-form">
             
-                <header class="ui-widget ui-widget-header">@user.FullName</header>
+                <header class="ui-widget ui-widget-header">@user.FullName @(!user.IsActive ? " (User no longer Active (Probably left the university) They should be removed.)" : string.Empty)</header>
             
                 @{
                 var perms = Model.Permissions.Where(a => a.User == user).OrderBy(a => a.Workgroup.Name).ThenBy(a => a.Role.Level);

--- a/Purchasing.Mvc/Views/Workgroup/People.cshtml
+++ b/Purchasing.Mvc/Views/Workgroup/People.cshtml
@@ -227,6 +227,10 @@
             <td>
                 <a href='@Url.Action("DeletePeople", new { workgroupPermissionId = item.FirstWorkgroupPermissionId, id = @Model.Workgroup.Id, @ViewBag.rolefilter })' title="Delete" class="ui-icon ui-icon-trash">
                 </a>
+                @if (!item.User.IsActive)
+                {
+                    <span title="User has been deactivated and should be removed."> *Deactivated</span>
+                }
             </td>
 		
 		</tr>


### PR DESCRIPTION
Issue #278
This will display them so they can be removed. If would be better to go through and fix every place where we look at users, but this gets us most of the way. The only way users get inactived is if we do it manually when we notice emails bouncing.