### PR TITLE
Elastic Search Update

### DIFF
--- a/Purchasing.Core/Purchasing.Core.csproj
+++ b/Purchasing.Core/Purchasing.Core.csproj
@@ -116,8 +116,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\DataAnnotationsExtensions.1.1.0.0\lib\NETFramework40\DataAnnotationsExtensions.dll</HintPath>
     </Reference>
-    <Reference Include="Elasticsearch.Net, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\Elasticsearch.Net.2.4.7\lib\net45\Elasticsearch.Net.dll</HintPath>
+    <Reference Include="Elasticsearch.Net, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\packages\Elasticsearch.Net.7.3.0\lib\net461\Elasticsearch.Net.dll</HintPath>
     </Reference>
     <Reference Include="FluentNHibernate, Version=1.4.0.0, Culture=neutral, PublicKeyToken=8aa435e3cb308880, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -126,8 +126,8 @@
     <Reference Include="Iesi.Collections">
       <HintPath>..\packages\Iesi.Collections.3.2.0.4000\lib\Net35\Iesi.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="Nest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\NEST.2.4.7\lib\net45\Nest.dll</HintPath>
+    <Reference Include="Nest, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\packages\NEST.7.3.0\lib\net461\Nest.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -137,9 +137,15 @@
       <HintPath>..\packages\NHibernate.3.3.1.4000\lib\Net35\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.5.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Purchasing.Core/Purchasing.Core.csproj
+++ b/Purchasing.Core/Purchasing.Core.csproj
@@ -129,8 +129,11 @@
     <Reference Include="Nest, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
       <HintPath>..\packages\NEST.7.3.0\lib\net461\Nest.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Nest.JsonNetSerializer, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\packages\NEST.JsonNetSerializer.7.3.0\lib\net461\Nest.JsonNetSerializer.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NHibernate, Version=3.3.1.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Purchasing.Core/Services/IndexSearchService.cs
+++ b/Purchasing.Core/Services/IndexSearchService.cs
@@ -210,6 +210,9 @@ namespace Purchasing.Core.Services
                 timeField = "minutesToAccountManagerComplete";
             }
 
+            // get the .keyword version of the index, for aggregates (since we aren't full text searching against the field)
+            roleNames = roleNames + ".keyword";
+
             var results = _client.Search<OrderTrackingEntity>(
                 s => s.Index(index)
                     .Size(size)

--- a/Purchasing.Core/Services/IndexService.cs
+++ b/Purchasing.Core/Services/IndexService.cs
@@ -279,7 +279,7 @@ namespace Purchasing.Core.Services
             //TODO: no idea if this will work
             var indexName = IndexHelper.GetIndexName(index);
 
-            return Convert.ToDateTime(_client.IndicesStats(indexName).Indices[indexName].Total.Indexing.Time);
+            return Convert.ToDateTime(_client.Indices.Stats(indexName).Indices[indexName].Total.Indexing.Time);
         }
 
         public int NumRecords(Indexes index)

--- a/Purchasing.Core/Services/IndexService.cs
+++ b/Purchasing.Core/Services/IndexService.cs
@@ -201,12 +201,13 @@ namespace Purchasing.Core.Services
 
             if (updatedOrderIds.Any())
             {
+
+
                 //Clear out existing lines and custom fields for the orders we are about to recreate
-                _client.DeleteByQuery<SearchResults.LineResult>(Indices.Index(IndexHelper.GetIndexName(Indexes.LineItems)), Types.All, q=> q.Query(rq => rq.Terms(t => t.Field(f => f.OrderId).Terms(updatedOrderIds))));
+                _client.DeleteByQuery<SearchResults.LineResult>(d => d.Index(Indices.Index(IndexHelper.GetIndexName(Indexes.LineItems))).Query(rq => rq.Terms(t => t.Field(f => f.OrderId).Terms(updatedOrderIds))));
 
-                _client.DeleteByQuery<SearchResults.CustomFieldResult>(Indices.Index(IndexHelper.GetIndexName(Indexes.CustomAnswers)), Types.All, q => q.Query(rq => rq.Terms(t => t.Field(f => f.OrderId).Terms(updatedOrderIds))));
-
-                _client.DeleteByQuery<OrderTrackingEntity>(Indices.Index(IndexHelper.GetIndexName(Indexes.OrderTracking)), Types.All, q => q.Query(rq => rq.Terms(t => t.Field(f => f.OrderId).Terms(updatedOrderIds))));
+                _client.DeleteByQuery<SearchResults.CustomFieldResult>(d => d.Index(Indices.Index(IndexHelper.GetIndexName(Indexes.CustomAnswers))).Query(rq => rq.Terms(t => t.Field(f => f.OrderId).Terms(updatedOrderIds))));
+                _client.DeleteByQuery<OrderTrackingEntity>(d => d.Index(Indices.Index(IndexHelper.GetIndexName(Indexes.OrderTracking))).Query(rq => rq.Terms(t => t.Field(f => f.OrderId).Terms(updatedOrderIds))));
 
                 WriteIndex(orderHistoryEntries, Indexes.OrderHistory, e => e.OrderId, recreate: false);
                 WriteIndex(lineItems, Indexes.LineItems, recreate: false);

--- a/Purchasing.Core/Services/IndexService.cs
+++ b/Purchasing.Core/Services/IndexService.cs
@@ -279,7 +279,14 @@ namespace Purchasing.Core.Services
             //TODO: no idea if this will work
             var indexName = IndexHelper.GetIndexName(index);
 
-            return Convert.ToDateTime(_client.Indices.Stats(indexName).Indices[indexName].Total.Indexing.Time);
+            var indexStats = _client.Indices.Stats(indexName);
+
+            if (indexStats.IsValid && indexStats.Indices.ContainsKey(indexName))
+            {
+                return Convert.ToDateTime(indexStats.Indices[indexName].Total.Indexing.Time);
+            }
+
+            return Convert.ToDateTime(DateTime.MinValue);
         }
 
         public int NumRecords(Indexes index)

--- a/Purchasing.Core/Services/IndexService.cs
+++ b/Purchasing.Core/Services/IndexService.cs
@@ -6,7 +6,9 @@ using System.Linq;
 using System.Text;
 using AutoMapper.Internal;
 using Dapper;
+using Elasticsearch.Net;
 using Nest;
+using Nest.JsonNetSerializer;
 using Purchasing.Core.Domain;
 using Purchasing.Core.Helpers;
 using Purchasing.Core.Queries;
@@ -64,8 +66,10 @@ namespace Purchasing.Core.Services
         public ElasticSearchIndexService(IDbService dbService)
         {
             _dbService = dbService;
-            
-            var settings = new ConnectionSettings(new Uri(ConfigurationManager.AppSettings["ElasticSearchUrl"]));
+
+            var pool = new SingleNodeConnectionPool(new Uri(ConfigurationManager.AppSettings["ElasticSearchUrl"]));
+            var settings = new ConnectionSettings(pool, JsonNetSerializer.Default);
+
             settings.DefaultIndex("prepurchasing");
 
             _client = new ElasticClient(settings);

--- a/Purchasing.Core/Services/IndexService.cs
+++ b/Purchasing.Core/Services/IndexService.cs
@@ -412,8 +412,8 @@ namespace Purchasing.Core.Services
             
             if (recreate) //TODO: might have to check to see if index exists first time
             {
-                _client.DeleteIndex(index);
-                _client.CreateIndex(index);
+                _client.Indices.Delete(index);
+                _client.Indices.Create(index);
             }
 
             var batches = entities.Partition(5000).ToArray(); //split into batches of up to 5000

--- a/Purchasing.Core/app.config
+++ b/Purchasing.Core/app.config
@@ -12,7 +12,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Purchasing.Core/app.config
+++ b/Purchasing.Core/app.config
@@ -1,19 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.3.0.4000" newVersion="3.3.0.4000"/>
+        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.3.0.4000" newVersion="3.3.0.4000" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="FluentNHibernate" publicKeyToken="8aa435e3cb308880" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.3.0.727" newVersion="1.3.0.727"/>
+        <assemblyIdentity name="FluentNHibernate" publicKeyToken="8aa435e3cb308880" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.3.0.727" newVersion="1.3.0.727" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" /></startup></configuration>

--- a/Purchasing.Core/packages.config
+++ b/Purchasing.Core/packages.config
@@ -3,11 +3,13 @@
   <package id="AutoMapper" version="3.3.1" targetFramework="net451" />
   <package id="Dapper" version="1.38" targetFramework="net451" />
   <package id="DataAnnotationsExtensions" version="1.1.0.0" targetFramework="net451" />
-  <package id="Elasticsearch.Net" version="2.4.7" targetFramework="net452" requireReinstallation="true" />
+  <package id="Elasticsearch.Net" version="7.3.0" targetFramework="net462" />
   <package id="FluentNHibernate" version="1.4.0.0" targetFramework="net451" />
   <package id="Iesi.Collections" version="3.2.0.4000" requireReinstallation="True" />
-  <package id="NEST" version="2.4.7" targetFramework="net452" requireReinstallation="true" />
+  <package id="NEST" version="7.3.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NHibernate" version="3.3.1.4000" targetFramework="net451" />
+  <package id="System.Buffers" version="4.5.0" targetFramework="net462" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net462" />
   <package id="UcdArch" version="5.1.0.145" targetFramework="net451" />
 </packages>

--- a/Purchasing.Core/packages.config
+++ b/Purchasing.Core/packages.config
@@ -7,7 +7,8 @@
   <package id="FluentNHibernate" version="1.4.0.0" targetFramework="net451" />
   <package id="Iesi.Collections" version="3.2.0.4000" requireReinstallation="True" />
   <package id="NEST" version="7.3.0" targetFramework="net462" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="NEST.JsonNetSerializer" version="7.3.0" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
   <package id="NHibernate" version="3.3.1.4000" targetFramework="net451" />
   <package id="System.Buffers" version="4.5.0" targetFramework="net462" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net462" />

--- a/Purchasing.Jobs.Common/app.config
+++ b/Purchasing.Jobs.Common/app.config
@@ -15,7 +15,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Purchasing.Jobs.Common/app.config
+++ b/Purchasing.Jobs.Common/app.config
@@ -1,28 +1,28 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net"/>
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
   </configSections>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0"/>
+        <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0"/>
+        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <appSettings>
-    <add key="Stackify.AppName" value="Purchasing"/>
-    <add key="Stackify.Environment" value=""/>
-    <add key="Stackify.ProxyServer" value=""/>
-    <add key="Stackify.ApiKey" value="[External]"/>
+    <add key="Stackify.AppName" value="Purchasing" />
+    <add key="Stackify.Environment" value="" />
+    <add key="Stackify.ProxyServer" value="" />
+    <add key="Stackify.ApiKey" value="[External]" />
   </appSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" /></startup></configuration>

--- a/Purchasing.Jobs.CreateOrderIndexes/App.config
+++ b/Purchasing.Jobs.CreateOrderIndexes/App.config
@@ -14,7 +14,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />

--- a/Purchasing.Jobs.CreateOrderIndexes/App.config
+++ b/Purchasing.Jobs.CreateOrderIndexes/App.config
@@ -1,30 +1,30 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net"/>
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
   </configSections>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0"/>
+        <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0"/>
+        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <appSettings>
-    <add key="Stackify.AppName" value="Purchasing.Jobs.CreateOrderIndexes"/>
-    <add key="Stackify.Environment" value="[External]"/>
-    <add key="Stackify.ApiKey" value="[External]"/>
+    <add key="Stackify.AppName" value="Purchasing.Jobs.CreateOrderIndexes" />
+    <add key="Stackify.Environment" value="[External]" />
+    <add key="Stackify.ApiKey" value="[External]" />
   </appSettings>
 </configuration>

--- a/Purchasing.Jobs.CreateOrderIndexes/Purchasing.Jobs.CreateOrderIndexes.csproj
+++ b/Purchasing.Jobs.CreateOrderIndexes/Purchasing.Jobs.CreateOrderIndexes.csproj
@@ -78,8 +78,8 @@
     <Reference Include="Nest, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
       <HintPath>..\packages\NEST.7.3.0\lib\net461\Nest.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Ninject">
       <HintPath>..\packages\Ninject.3.2.2.0\lib\net45-full\Ninject.dll</HintPath>

--- a/Purchasing.Jobs.CreateOrderIndexes/Purchasing.Jobs.CreateOrderIndexes.csproj
+++ b/Purchasing.Jobs.CreateOrderIndexes/Purchasing.Jobs.CreateOrderIndexes.csproj
@@ -44,8 +44,8 @@
     <Reference Include="Dapper">
       <HintPath>..\packages\Dapper.1.38\lib\net45\Dapper.dll</HintPath>
     </Reference>
-    <Reference Include="Elasticsearch.Net, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\Elasticsearch.Net.2.4.7\lib\net45\Elasticsearch.Net.dll</HintPath>
+    <Reference Include="Elasticsearch.Net, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\packages\Elasticsearch.Net.7.3.0\lib\net461\Elasticsearch.Net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=1.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -75,8 +75,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\WindowsAzure.Storage.4.0.1\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
-    <Reference Include="Nest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\NEST.2.4.7\lib\net45\Nest.dll</HintPath>
+    <Reference Include="Nest, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\packages\NEST.7.3.0\lib\net461\Nest.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -101,7 +101,13 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.5.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Spatial, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Spatial.5.6.0\lib\net40\System.Spatial.dll</HintPath>
     </Reference>

--- a/Purchasing.Jobs.CreateOrderIndexes/packages.config
+++ b/Purchasing.Jobs.CreateOrderIndexes/packages.config
@@ -12,7 +12,7 @@
   <package id="Microsoft.Web.WebJobs.Publish" version="1.0.2" targetFramework="net451" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net451" />
   <package id="NEST" version="7.3.0" targetFramework="net462" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net451" />
   <package id="OctoPack" version="3.0.71" targetFramework="net451" developmentDependency="true" />
   <package id="Serilog" version="1.5.7" targetFramework="net451" />

--- a/Purchasing.Jobs.CreateOrderIndexes/packages.config
+++ b/Purchasing.Jobs.CreateOrderIndexes/packages.config
@@ -3,7 +3,7 @@
   <package id="AutoMapper" version="3.3.1" targetFramework="net451" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net451" />
   <package id="Dapper" version="1.38" targetFramework="net451" />
-  <package id="Elasticsearch.Net" version="2.4.7" targetFramework="net452" requireReinstallation="true" />
+  <package id="Elasticsearch.Net" version="7.3.0" targetFramework="net462" />
   <package id="Microsoft.Azure.WebJobs" version="1.0.1" targetFramework="net451" />
   <package id="Microsoft.Azure.WebJobs.Core" version="1.0.1" targetFramework="net451" />
   <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net451" />
@@ -11,13 +11,15 @@
   <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net451" />
   <package id="Microsoft.Web.WebJobs.Publish" version="1.0.2" targetFramework="net451" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net451" />
-  <package id="NEST" version="2.4.7" targetFramework="net452" requireReinstallation="true" />
+  <package id="NEST" version="7.3.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net451" />
   <package id="OctoPack" version="3.0.71" targetFramework="net451" developmentDependency="true" />
   <package id="Serilog" version="1.5.7" targetFramework="net451" />
   <package id="Serilog.Sinks.Stackify" version="1.0.12.0" targetFramework="net451" />
   <package id="StackifyLib" version="1.12.0.0" targetFramework="net451" />
+  <package id="System.Buffers" version="4.5.0" targetFramework="net462" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net462" />
   <package id="System.Spatial" version="5.6.0" targetFramework="net451" />
   <package id="UcdArch" version="5.1.0.145" targetFramework="net451" />
   <package id="WindowsAzure.Storage" version="4.0.1" targetFramework="net451" />

--- a/Purchasing.Jobs.DailyEmailNotifications/App.config
+++ b/Purchasing.Jobs.DailyEmailNotifications/App.config
@@ -10,7 +10,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Purchasing.Jobs.DailyEmailNotifications/App.config
+++ b/Purchasing.Jobs.DailyEmailNotifications/App.config
@@ -1,30 +1,30 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net"/>
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
   </configSections>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0"/>
+        <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0"/>
+        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <appSettings>
-    <add key="Stackify.AppName" value="Purchasing.Jobs.DailyEmailNotifications"/>
-    <add key="Stackify.Environment" value="[External]"/>
-    <add key="Stackify.ApiKey" value="[External]"/>
+    <add key="Stackify.AppName" value="Purchasing.Jobs.DailyEmailNotifications" />
+    <add key="Stackify.Environment" value="[External]" />
+    <add key="Stackify.ApiKey" value="[External]" />
   </appSettings>
 </configuration>

--- a/Purchasing.Jobs.DailyEmailNotifications/Purchasing.Jobs.DailyEmailNotifications.csproj
+++ b/Purchasing.Jobs.DailyEmailNotifications/Purchasing.Jobs.DailyEmailNotifications.csproj
@@ -62,8 +62,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\WindowsAzure.Storage.4.0.1\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Ninject">
       <HintPath>..\packages\Ninject.3.2.2.0\lib\net45-full\Ninject.dll</HintPath>

--- a/Purchasing.Jobs.DailyEmailNotifications/packages.config
+++ b/Purchasing.Jobs.DailyEmailNotifications/packages.config
@@ -8,7 +8,7 @@
   <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net451" />
   <package id="Microsoft.Web.WebJobs.Publish" version="1.0.3" targetFramework="net451" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net451" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net451" />
   <package id="OctoPack" version="3.0.71" targetFramework="net451" developmentDependency="true" />
   <package id="Serilog" version="1.5.7" targetFramework="net451" />

--- a/Purchasing.Jobs.EmailNotifications/App.config
+++ b/Purchasing.Jobs.EmailNotifications/App.config
@@ -1,34 +1,34 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net"/>
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
   </configSections>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.0.3.0" newVersion="3.0.3.0"/>
+        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.3.0" newVersion="3.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0"/>
+        <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0"/>
+        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <appSettings>
-    <add key="Stackify.AppName" value="Purchasing.Jobs.EmailNotifications"/>
-    <add key="Stackify.Environment" value="[External]"/>
-    <add key="Stackify.ApiKey" value="[External]"/>
+    <add key="Stackify.AppName" value="Purchasing.Jobs.EmailNotifications" />
+    <add key="Stackify.Environment" value="[External]" />
+    <add key="Stackify.ApiKey" value="[External]" />
   </appSettings>
 </configuration>

--- a/Purchasing.Jobs.EmailNotifications/App.config
+++ b/Purchasing.Jobs.EmailNotifications/App.config
@@ -10,7 +10,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Purchasing.Jobs.EmailNotifications/Purchasing.Jobs.EmailNotifications.csproj
+++ b/Purchasing.Jobs.EmailNotifications/Purchasing.Jobs.EmailNotifications.csproj
@@ -63,8 +63,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\WindowsAzure.Storage.4.0.1\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Ninject">
       <HintPath>..\packages\Ninject.3.2.2.0\lib\net45-full\Ninject.dll</HintPath>

--- a/Purchasing.Jobs.EmailNotifications/packages.config
+++ b/Purchasing.Jobs.EmailNotifications/packages.config
@@ -8,7 +8,7 @@
   <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net451" />
   <package id="Microsoft.Web.WebJobs.Publish" version="1.0.3" targetFramework="net451" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net451" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net451" />
   <package id="OctoPack" version="3.0.71" targetFramework="net451" developmentDependency="true" />
   <package id="Serilog" version="1.5.7" targetFramework="net451" />

--- a/Purchasing.Jobs.NightlySync/App.config
+++ b/Purchasing.Jobs.NightlySync/App.config
@@ -14,7 +14,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />

--- a/Purchasing.Jobs.NightlySync/App.config
+++ b/Purchasing.Jobs.NightlySync/App.config
@@ -1,30 +1,30 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net"/>
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
   </configSections>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0"/>
+        <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0"/>
+        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <appSettings>
-    <add key="Stackify.AppName" value="Purchasing.Jobs.NightlySync"/>
-    <add key="Stackify.Environment" value="[External]"/>
-    <add key="Stackify.ApiKey" value="[External]"/>
+    <add key="Stackify.AppName" value="Purchasing.Jobs.NightlySync" />
+    <add key="Stackify.Environment" value="[External]" />
+    <add key="Stackify.ApiKey" value="[External]" />
   </appSettings>
 </configuration>

--- a/Purchasing.Jobs.NightlySync/Purchasing.Jobs.NightlySync.csproj
+++ b/Purchasing.Jobs.NightlySync/Purchasing.Jobs.NightlySync.csproj
@@ -66,9 +66,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\WindowsAzure.Storage.4.0.1\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Ninject, Version=3.2.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Purchasing.Jobs.NightlySync/packages.config
+++ b/Purchasing.Jobs.NightlySync/packages.config
@@ -9,7 +9,7 @@
   <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net451" />
   <package id="Microsoft.Web.WebJobs.Publish" version="1.0.3" targetFramework="net451" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net451" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net451" />
   <package id="OctoPack" version="3.0.71" targetFramework="net451" developmentDependency="true" />
   <package id="Serilog" version="1.5.7" targetFramework="net451" />

--- a/Purchasing.Jobs.NotificationsCommon/Purchasing.Jobs.NotificationsCommon.csproj
+++ b/Purchasing.Jobs.NotificationsCommon/Purchasing.Jobs.NotificationsCommon.csproj
@@ -45,9 +45,8 @@
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.1.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="SendGrid.SmtpApi">
       <HintPath>..\packages\SendGrid.SmtpApi.1.1.3\lib\net40\SendGrid.SmtpApi.dll</HintPath>

--- a/Purchasing.Jobs.NotificationsCommon/app.config
+++ b/Purchasing.Jobs.NotificationsCommon/app.config
@@ -1,25 +1,25 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0"/>
+        <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0"/>
+        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <appSettings>
-    <add key="Stackify.AppName" value="Purchasing.Jobs.NotificationsCommon"/>
-    <add key="Stackify.Environment" value=""/>
-    <add key="Stackify.ProxyServer" value=""/>
-    <add key="Stackify.ApiKey" value=""/>
+    <add key="Stackify.AppName" value="Purchasing.Jobs.NotificationsCommon" />
+    <add key="Stackify.Environment" value="" />
+    <add key="Stackify.ProxyServer" value="" />
+    <add key="Stackify.ApiKey" value="" />
   </appSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" /></startup></configuration>

--- a/Purchasing.Jobs.NotificationsCommon/app.config
+++ b/Purchasing.Jobs.NotificationsCommon/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Purchasing.Jobs.NotificationsCommon/packages.config
+++ b/Purchasing.Jobs.NotificationsCommon/packages.config
@@ -4,7 +4,7 @@
   <package id="Flurl" version="1.0.7" targetFramework="net451" />
   <package id="Flurl.Http" version="0.6.0" targetFramework="net451" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net451" />
-  <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
   <package id="Sendgrid" version="5.0.0" targetFramework="net451" />
   <package id="SendGrid.SmtpApi" version="1.1.3" targetFramework="net451" />
   <package id="Serilog" version="1.5.7" targetFramework="net451" />

--- a/Purchasing.Jobs.UpdateLookupIndexes/App.config
+++ b/Purchasing.Jobs.UpdateLookupIndexes/App.config
@@ -1,30 +1,30 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net"/>
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
   </configSections>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0"/>
+        <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0"/>
+        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <appSettings>
-    <add key="Stackify.AppName" value="Purchasing.Jobs.UpdateLookupIndexes"/>
-    <add key="Stackify.Environment" value="[External]"/>
-    <add key="Stackify.ApiKey" value="[External]"/>
+    <add key="Stackify.AppName" value="Purchasing.Jobs.UpdateLookupIndexes" />
+    <add key="Stackify.Environment" value="[External]" />
+    <add key="Stackify.ApiKey" value="[External]" />
   </appSettings>
 </configuration>

--- a/Purchasing.Jobs.UpdateLookupIndexes/App.config
+++ b/Purchasing.Jobs.UpdateLookupIndexes/App.config
@@ -14,7 +14,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />

--- a/Purchasing.Jobs.UpdateLookupIndexes/Purchasing.Jobs.UpdateLookupIndexes.csproj
+++ b/Purchasing.Jobs.UpdateLookupIndexes/Purchasing.Jobs.UpdateLookupIndexes.csproj
@@ -59,8 +59,8 @@
     <Reference Include="Dapper">
       <HintPath>..\packages\Dapper.1.38\lib\net45\Dapper.dll</HintPath>
     </Reference>
-    <Reference Include="Elasticsearch.Net, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\Elasticsearch.Net.2.4.7\lib\net45\Elasticsearch.Net.dll</HintPath>
+    <Reference Include="Elasticsearch.Net, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\packages\Elasticsearch.Net.7.3.0\lib\net461\Elasticsearch.Net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=1.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -90,8 +90,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\WindowsAzure.Storage.4.0.1\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
-    <Reference Include="Nest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\NEST.2.4.7\lib\net45\Nest.dll</HintPath>
+    <Reference Include="Nest, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\packages\NEST.7.3.0\lib\net461\Nest.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -116,7 +116,13 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.5.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Spatial, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Spatial.5.6.0\lib\net40\System.Spatial.dll</HintPath>
     </Reference>

--- a/Purchasing.Jobs.UpdateLookupIndexes/Purchasing.Jobs.UpdateLookupIndexes.csproj
+++ b/Purchasing.Jobs.UpdateLookupIndexes/Purchasing.Jobs.UpdateLookupIndexes.csproj
@@ -93,8 +93,8 @@
     <Reference Include="Nest, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
       <HintPath>..\packages\NEST.7.3.0\lib\net461\Nest.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Ninject">
       <HintPath>..\packages\Ninject.3.2.2.0\lib\net45-full\Ninject.dll</HintPath>

--- a/Purchasing.Jobs.UpdateLookupIndexes/packages.config
+++ b/Purchasing.Jobs.UpdateLookupIndexes/packages.config
@@ -12,7 +12,7 @@
   <package id="Microsoft.Web.WebJobs.Publish" version="1.0.2" targetFramework="net451" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net451" />
   <package id="NEST" version="7.3.0" targetFramework="net462" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net451" />
   <package id="OctoPack" version="3.0.71" targetFramework="net451" developmentDependency="true" />
   <package id="Serilog" version="1.5.7" targetFramework="net451" />

--- a/Purchasing.Jobs.UpdateLookupIndexes/packages.config
+++ b/Purchasing.Jobs.UpdateLookupIndexes/packages.config
@@ -3,7 +3,7 @@
   <package id="AutoMapper" version="3.3.1" targetFramework="net451" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net451" />
   <package id="Dapper" version="1.38" targetFramework="net451" />
-  <package id="Elasticsearch.Net" version="2.4.7" targetFramework="net452" requireReinstallation="true" />
+  <package id="Elasticsearch.Net" version="7.3.0" targetFramework="net462" />
   <package id="Microsoft.Azure.WebJobs" version="1.0.1" targetFramework="net451" />
   <package id="Microsoft.Azure.WebJobs.Core" version="1.0.1" targetFramework="net451" />
   <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net451" />
@@ -11,13 +11,15 @@
   <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net451" />
   <package id="Microsoft.Web.WebJobs.Publish" version="1.0.2" targetFramework="net451" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net451" />
-  <package id="NEST" version="2.4.7" targetFramework="net452" requireReinstallation="true" />
+  <package id="NEST" version="7.3.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net451" />
   <package id="OctoPack" version="3.0.71" targetFramework="net451" developmentDependency="true" />
   <package id="Serilog" version="1.5.7" targetFramework="net451" />
   <package id="Serilog.Sinks.Stackify" version="1.0.12.0" targetFramework="net451" />
   <package id="StackifyLib" version="1.12.0.0" targetFramework="net451" />
+  <package id="System.Buffers" version="4.5.0" targetFramework="net462" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net462" />
   <package id="System.Spatial" version="5.6.0" targetFramework="net451" />
   <package id="UcdArch" version="5.1.0.145" targetFramework="net451" />
   <package id="WindowsAzure.Storage" version="4.0.1" targetFramework="net451" />

--- a/Purchasing.Jobs.UpdateOrderIndexes/App.config
+++ b/Purchasing.Jobs.UpdateOrderIndexes/App.config
@@ -14,7 +14,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />

--- a/Purchasing.Jobs.UpdateOrderIndexes/App.config
+++ b/Purchasing.Jobs.UpdateOrderIndexes/App.config
@@ -1,30 +1,30 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net"/>
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
   </configSections>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0"/>
+        <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0"/>
+        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <appSettings>
-    <add key="Stackify.AppName" value="Purchasing.Jobs.UpdateOrderIndexes"/>
-    <add key="Stackify.Environment" value="[External]"/>
-    <add key="Stackify.ApiKey" value="[External]"/>
+    <add key="Stackify.AppName" value="Purchasing.Jobs.UpdateOrderIndexes" />
+    <add key="Stackify.Environment" value="[External]" />
+    <add key="Stackify.ApiKey" value="[External]" />
   </appSettings>
 </configuration>

--- a/Purchasing.Jobs.UpdateOrderIndexes/Purchasing.Jobs.UpdateOrderIndexes.csproj
+++ b/Purchasing.Jobs.UpdateOrderIndexes/Purchasing.Jobs.UpdateOrderIndexes.csproj
@@ -81,8 +81,8 @@
     <Reference Include="Nest, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
       <HintPath>..\packages\NEST.7.3.0\lib\net461\Nest.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Ninject">
       <HintPath>..\packages\Ninject.3.2.2.0\lib\net45-full\Ninject.dll</HintPath>

--- a/Purchasing.Jobs.UpdateOrderIndexes/Purchasing.Jobs.UpdateOrderIndexes.csproj
+++ b/Purchasing.Jobs.UpdateOrderIndexes/Purchasing.Jobs.UpdateOrderIndexes.csproj
@@ -46,8 +46,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Dapper.1.38\lib\net45\Dapper.dll</HintPath>
     </Reference>
-    <Reference Include="Elasticsearch.Net, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\Elasticsearch.Net.2.4.7\lib\net45\Elasticsearch.Net.dll</HintPath>
+    <Reference Include="Elasticsearch.Net, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\packages\Elasticsearch.Net.7.3.0\lib\net461\Elasticsearch.Net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=1.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -78,8 +78,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\WindowsAzure.Storage.4.0.1\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
-    <Reference Include="Nest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\NEST.2.4.7\lib\net45\Nest.dll</HintPath>
+    <Reference Include="Nest, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\packages\NEST.7.3.0\lib\net461\Nest.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -104,7 +104,13 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.5.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Spatial, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Spatial.5.6.0\lib\net40\System.Spatial.dll</HintPath>
     </Reference>

--- a/Purchasing.Jobs.UpdateOrderIndexes/packages.config
+++ b/Purchasing.Jobs.UpdateOrderIndexes/packages.config
@@ -12,7 +12,7 @@
   <package id="Microsoft.Web.WebJobs.Publish" version="1.0.2" targetFramework="net451" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net451" />
   <package id="NEST" version="7.3.0" targetFramework="net462" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net451" />
   <package id="OctoPack" version="3.0.71" targetFramework="net451" developmentDependency="true" />
   <package id="Serilog" version="1.5.7" targetFramework="net451" />

--- a/Purchasing.Jobs.UpdateOrderIndexes/packages.config
+++ b/Purchasing.Jobs.UpdateOrderIndexes/packages.config
@@ -3,7 +3,7 @@
   <package id="AutoMapper" version="3.3.1" targetFramework="net451" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net451" />
   <package id="Dapper" version="1.38" targetFramework="net451" />
-  <package id="Elasticsearch.Net" version="2.4.7" targetFramework="net452" requireReinstallation="true" />
+  <package id="Elasticsearch.Net" version="7.3.0" targetFramework="net462" />
   <package id="Microsoft.Azure.WebJobs" version="1.0.1" targetFramework="net451" />
   <package id="Microsoft.Azure.WebJobs.Core" version="1.0.1" targetFramework="net451" />
   <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net451" />
@@ -11,13 +11,15 @@
   <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net451" />
   <package id="Microsoft.Web.WebJobs.Publish" version="1.0.2" targetFramework="net451" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net451" />
-  <package id="NEST" version="2.4.7" targetFramework="net452" requireReinstallation="true" />
+  <package id="NEST" version="7.3.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net451" />
   <package id="OctoPack" version="3.0.71" targetFramework="net451" developmentDependency="true" />
   <package id="Serilog" version="1.5.7" targetFramework="net451" />
   <package id="Serilog.Sinks.Stackify" version="1.0.12.0" targetFramework="net451" />
   <package id="StackifyLib" version="1.12.0.0" targetFramework="net451" />
+  <package id="System.Buffers" version="4.5.0" targetFramework="net462" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net462" />
   <package id="System.Spatial" version="5.6.0" targetFramework="net451" />
   <package id="UcdArch" version="5.1.0.145" targetFramework="net451" />
   <package id="WindowsAzure.Storage" version="4.0.1" targetFramework="net451" />

--- a/Purchasing.Mvc/Controllers/SystemController.cs
+++ b/Purchasing.Mvc/Controllers/SystemController.cs
@@ -39,7 +39,8 @@ namespace Purchasing.Mvc.Controllers
         {
             ViewBag.ModifiedDates = new Dictionary<string, DateTime>
                                     {
-                                        {"OrderHistory", _indexService.LastModified(Core.Services.Indexes.OrderHistory)}
+                                        {"OrderHistory", _indexService.LastModified(Core.Services.Indexes.OrderHistory)},
+                                        {"OrderTracking", _indexService.LastModified(Core.Services.Indexes.OrderTracking)}
                                         ,{"LineItems", _indexService.LastModified(Core.Services.Indexes.LineItems)}
                                         ,{"Comments", _indexService.LastModified(Core.Services.Indexes.Comments)}
                                         ,{"CustomAnswers", _indexService.LastModified(Core.Services.Indexes.CustomAnswers)}
@@ -52,6 +53,7 @@ namespace Purchasing.Mvc.Controllers
             ViewBag.NumRecords = new Dictionary<string, int>
                                      {
                                          {"OrderHistory", _indexService.NumRecords(Core.Services.Indexes.OrderHistory)}
+                                         ,{"OrderTracking", _indexService.NumRecords(Core.Services.Indexes.OrderTracking)}
                                          ,{"LineItems", _indexService.NumRecords(Core.Services.Indexes.LineItems)}
                                          ,{"Comments", _indexService.NumRecords(Core.Services.Indexes.Comments)}
                                          ,{"CustomAnswers", _indexService.NumRecords(Core.Services.Indexes.CustomAnswers)}
@@ -70,6 +72,9 @@ namespace Purchasing.Mvc.Controllers
             {
                 case "OrderHistory":
                     _indexService.CreateHistoricalOrderIndex();
+                    break;
+                case "OrderTracking":
+                    _indexService.CreateTrackingIndex();
                     break;
                 case "LineItems":
                     _indexService.CreateLineItemsIndex();

--- a/Purchasing.Mvc/Purchasing.Mvc.csproj
+++ b/Purchasing.Mvc/Purchasing.Mvc.csproj
@@ -147,8 +147,8 @@
     <Reference Include="Nest, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
       <HintPath>..\packages\NEST.7.3.0\lib\net461\Nest.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NHibernate">
       <HintPath>..\packages\NHibernate.3.3.1.4000\lib\Net35\NHibernate.dll</HintPath>

--- a/Purchasing.Mvc/Purchasing.Mvc.csproj
+++ b/Purchasing.Mvc/Purchasing.Mvc.csproj
@@ -75,8 +75,8 @@
     <Reference Include="DataAnnotationsExtensions.ClientValidation">
       <HintPath>..\packages\DataAnnotationsExtensions.MVC3.1.1.0.0\lib\NETFramework40\DataAnnotationsExtensions.ClientValidation.dll</HintPath>
     </Reference>
-    <Reference Include="Elasticsearch.Net, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\Elasticsearch.Net.2.5.4\lib\net46\Elasticsearch.Net.dll</HintPath>
+    <Reference Include="Elasticsearch.Net, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\packages\Elasticsearch.Net.7.3.0\lib\net461\Elasticsearch.Net.dll</HintPath>
     </Reference>
     <Reference Include="Elmah">
       <HintPath>..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
@@ -144,8 +144,8 @@
     <Reference Include="MvcContrib.FluentHtml">
       <HintPath>..\packages\MvcContrib.Mvc3.FluentHtml-ci.3.0.100.0\lib\MvcContrib.FluentHtml.dll</HintPath>
     </Reference>
-    <Reference Include="Nest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\NEST.2.5.4\lib\net46\Nest.dll</HintPath>
+    <Reference Include="Nest, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\packages\NEST.7.3.0\lib\net461\Nest.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -192,8 +192,14 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.5.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.DirectoryServices.Protocols" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Spatial, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Purchasing.Mvc/Web.config
+++ b/Purchasing.Mvc/Web.config
@@ -21,7 +21,7 @@
     <add key="Stackify.Environment" value="[External]" />
     <add key="Stackify.ApiKey" value="[External]" />
     <add key="PersonLookupUrl" value="http://directory.ucdavis.edu/search/directory_results.shtml?filter=" />
-    <add key="IetWsKey" value="[External]"/>
+    <add key="IetWsKey" value="[External]" />
   </appSettings>
   <connectionStrings>
     <add name="MainDB" connectionString="data source=.\SQLExpress;Initial Catalog=PrePurchasing;Integrated Security=true;" providerName="System.Data.SqlClient" />

--- a/Purchasing.Mvc/Web.config
+++ b/Purchasing.Mvc/Web.config
@@ -58,7 +58,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />

--- a/Purchasing.Mvc/packages.config
+++ b/Purchasing.Mvc/packages.config
@@ -37,7 +37,7 @@
   <package id="Modernizr" version="2.8.3" targetFramework="net45" />
   <package id="MvcContrib.Mvc3.FluentHtml-ci" version="3.0.100.0" targetFramework="net45" />
   <package id="NEST" version="7.3.0" targetFramework="net462" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
   <package id="NHibernate" version="3.3.1.4000" targetFramework="net45" />
   <package id="NPOI" version="2.0.6" targetFramework="net451" />
   <package id="OctoPack" version="3.0.71" targetFramework="net451" developmentDependency="true" />

--- a/Purchasing.Mvc/packages.config
+++ b/Purchasing.Mvc/packages.config
@@ -10,7 +10,7 @@
   <package id="Dapper" version="1.38" targetFramework="net451" />
   <package id="DataAnnotationsExtensions" version="1.1.0.0" targetFramework="net45" />
   <package id="DataAnnotationsExtensions.MVC3" version="1.1.0.0" targetFramework="net45" />
-  <package id="Elasticsearch.Net" version="2.5.4" targetFramework="net462" />
+  <package id="Elasticsearch.Net" version="7.3.0" targetFramework="net462" />
   <package id="elmah" version="1.2.2" targetFramework="net45" />
   <package id="elmah.corelibrary" version="1.2.2" targetFramework="net45" />
   <package id="FluentNHibernate" version="1.4.0.0" targetFramework="net45" />
@@ -36,7 +36,7 @@
   <package id="MiniProfiler" version="3.1.1.140" targetFramework="net451" />
   <package id="Modernizr" version="2.8.3" targetFramework="net45" />
   <package id="MvcContrib.Mvc3.FluentHtml-ci" version="3.0.100.0" targetFramework="net45" />
-  <package id="NEST" version="2.5.4" targetFramework="net462" />
+  <package id="NEST" version="7.3.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net462" />
   <package id="NHibernate" version="3.3.1.4000" targetFramework="net45" />
   <package id="NPOI" version="2.0.6" targetFramework="net451" />
@@ -49,6 +49,8 @@
   <package id="SerilogWeb.Classic" version="2.0.6" targetFramework="net451" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net451" />
   <package id="StackifyLib" version="1.12.0.0" targetFramework="net451" />
+  <package id="System.Buffers" version="4.5.0" targetFramework="net462" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net462" />
   <package id="System.Spatial" version="5.8.1" targetFramework="net452" />
   <package id="UcdArch" version="5.1.0.145" targetFramework="net451" />
   <package id="UcdArch.Mvc" version="5.1.0.144" targetFramework="net45" />

--- a/Purchasing.Tests/App.config
+++ b/Purchasing.Tests/App.config
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- 
     Note: Add entries to the App.config file for configuration settings
     that apply only to the Test project.
 -->
 <configuration>
   <configSections>
-    <section name="hibernate-configuration" type="NHibernate.Cfg.ConfigurationSectionHandler, NHibernate"/>
+    <section name="hibernate-configuration" type="NHibernate.Cfg.ConfigurationSectionHandler, NHibernate" />
   </configSections>
   <hibernate-configuration xmlns="urn:nhibernate-configuration-2.2">
     <session-factory>
@@ -22,69 +22,69 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Data.SQLite" publicKeyToken="db937bc2d44ff139" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.0.66.0" newVersion="1.0.66.0"/>
+        <assemblyIdentity name="System.Data.SQLite" publicKeyToken="db937bc2d44ff139" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.0.66.0" newVersion="1.0.66.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="AjaxMin" publicKeyToken="21ef50ce11b5d80f" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.47.4452.34008" newVersion="4.47.4452.34008"/>
+        <assemblyIdentity name="AjaxMin" publicKeyToken="21ef50ce11b5d80f" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.47.4452.34008" newVersion="4.47.4452.34008" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="DataAnnotationsExtensions" publicKeyToken="358a5681c50fd84c" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
+        <assemblyIdentity name="DataAnnotationsExtensions" publicKeyToken="358a5681c50fd84c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.3.0.4000" newVersion="3.3.0.4000"/>
+        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.3.0.4000" newVersion="3.3.0.4000" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Castle.Windsor" publicKeyToken="407dd0808d44fbdc" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.5.1.0" newVersion="2.5.1.0"/>
+        <assemblyIdentity name="Castle.Windsor" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.5.1.0" newVersion="2.5.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2"/>
+        <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0"/>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930"/>
+        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0"/>
+        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.3" newVersion="2.1.0.3"/>
+        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.3" newVersion="2.1.0.3" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.VisualStudio.QualityTools.UnitTestFramework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0"/>
+        <assemblyIdentity name="Microsoft.VisualStudio.QualityTools.UnitTestFramework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0"/>
+        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0"/>
+        <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0"/>
+        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" /></startup></configuration>

--- a/Purchasing.Tests/App.config
+++ b/Purchasing.Tests/App.config
@@ -23,7 +23,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Data.SQLite" publicKeyToken="db937bc2d44ff139" culture="neutral" />

--- a/Purchasing.Tests/Purchasing.Tests.csproj
+++ b/Purchasing.Tests/Purchasing.Tests.csproj
@@ -137,9 +137,8 @@
     <Reference Include="MvcContrib.TestHelper">
       <HintPath>..\packages\MvcContrib.Mvc3.TestHelper-ci.3.0.100.0\lib\MvcContrib.TestHelper.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NHibernate">
       <HintPath>..\packages\NHibernate.3.3.1.4000\lib\Net35\NHibernate.dll</HintPath>

--- a/Purchasing.Tests/packages.config
+++ b/Purchasing.Tests/packages.config
@@ -11,7 +11,7 @@
   <package id="Microsoft.AspNet.WebPages" version="3.2.2" targetFramework="net451" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net451" />
   <package id="MvcContrib.Mvc3.TestHelper-ci" version="3.0.100.0" targetFramework="net451" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
   <package id="NHibernate" version="3.3.1.4000" targetFramework="net451" />
   <package id="RhinoMocks" version="3.6" targetFramework="net451" />
   <package id="SQLitex64" version="1.0.66" />

--- a/Purchasing.WS/app.config
+++ b/Purchasing.WS/app.config
@@ -30,7 +30,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Purchasing.WS/app.config
+++ b/Purchasing.WS/app.config
@@ -1,46 +1,46 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <system.serviceModel>
     <bindings>
       <basicHttpBinding>
-        <binding name="purchaseDocumentsInterfaceServiceSOAPSoapBinding"/>
+        <binding name="purchaseDocumentsInterfaceServiceSOAPSoapBinding" />
       </basicHttpBinding>
     </bindings>
     <client>
-      <endpoint address="http://kfs1.ucdavis.edu/kfs-prd/remoting/purchaseDocumentsInterfaceServiceSOAP" binding="basicHttpBinding" bindingConfiguration="purchaseDocumentsInterfaceServiceSOAPSoapBinding" contract="PurchaseDocumentService.purchasingDocumentsInterfaceServiceSOAP" name="purchasingDocumentsInterfaceServiceSOAPPort"/>
+      <endpoint address="http://kfs1.ucdavis.edu/kfs-prd/remoting/purchaseDocumentsInterfaceServiceSOAP" binding="basicHttpBinding" bindingConfiguration="purchaseDocumentsInterfaceServiceSOAPSoapBinding" contract="PurchaseDocumentService.purchasingDocumentsInterfaceServiceSOAP" name="purchasingDocumentsInterfaceServiceSOAPPort" />
     </client>
   </system.serviceModel>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0"/>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.3.1.4000" newVersion="3.3.1.4000"/>
+        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.3.1.4000" newVersion="3.3.1.4000" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="FluentNHibernate" publicKeyToken="8aa435e3cb308880" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.4.0.0" newVersion="1.4.0.0"/>
+        <assemblyIdentity name="FluentNHibernate" publicKeyToken="8aa435e3cb308880" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.4.0.0" newVersion="1.4.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
   </startup>
   <appSettings>
-    <add key="Stackify.AppName" value="Purchasing"/>
-    <add key="Stackify.Environment" value=""/>
-    <add key="Stackify.ProxyServer" value=""/>
-    <add key="Stackify.ApiKey" value="[External]"/>
+    <add key="Stackify.AppName" value="Purchasing" />
+    <add key="Stackify.Environment" value="" />
+    <add key="Stackify.ProxyServer" value="" />
+    <add key="Stackify.ApiKey" value="[External]" />
   </appSettings>
 </configuration>


### PR DESCRIPTION
Updated ES & NEST to the new 7.3 version from v2.  Minor changes were made to queries, aggregations, and stats APIs that I needed to account for.  Locally, I was able to rebuild all indexes and order history, searching and most reports seemed to work fine.

There is one report, which uses the aggregation from `GetOrderTrackingEntitiesByRole()`, which is not working.  That report aggregates based on the `purchaserId` field, which is a fully indexed text field.  ES no longer allows this, and recommends you don't do aggregates on text fields.  We can overwrite that recommendation, change to a non-analyzed text field, or add a new field, but we'll have to investigate the impact of our choice.  https://www.elastic.co/guide/en/elasticsearch/reference/current/fielddata.html