### PR TITLE
Add Elastic Logging

### DIFF
--- a/Purchasing.Core/Purchasing.Core.csproj
+++ b/Purchasing.Core/Purchasing.Core.csproj
@@ -127,10 +127,10 @@
       <HintPath>..\packages\Iesi.Collections.3.2.0.4000\lib\Net35\Iesi.Collections.dll</HintPath>
     </Reference>
     <Reference Include="Nest, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\NEST.7.3.0\lib\net461\Nest.dll</HintPath>
+      <HintPath>..\packages\NEST.7.8.1\lib\net461\Nest.dll</HintPath>
     </Reference>
     <Reference Include="Nest.JsonNetSerializer, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\NEST.JsonNetSerializer.7.3.0\lib\net461\Nest.JsonNetSerializer.dll</HintPath>
+      <HintPath>..\packages\NEST.JsonNetSerializer.7.8.1\lib\net461\Nest.JsonNetSerializer.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Purchasing.Core/Purchasing.Core.csproj
+++ b/Purchasing.Core/Purchasing.Core.csproj
@@ -117,7 +117,7 @@
       <HintPath>..\packages\DataAnnotationsExtensions.1.1.0.0\lib\NETFramework40\DataAnnotationsExtensions.dll</HintPath>
     </Reference>
     <Reference Include="Elasticsearch.Net, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\Elasticsearch.Net.7.3.0\lib\net461\Elasticsearch.Net.dll</HintPath>
+      <HintPath>..\packages\Elasticsearch.Net.7.8.1\lib\net461\Elasticsearch.Net.dll</HintPath>
     </Reference>
     <Reference Include="FluentNHibernate, Version=1.4.0.0, Culture=neutral, PublicKeyToken=8aa435e3cb308880, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Purchasing.Core/packages.config
+++ b/Purchasing.Core/packages.config
@@ -7,8 +7,8 @@
   <package id="FluentNHibernate" version="1.4.0.0" targetFramework="net451" />
   <package id="Iesi.Collections" version="3.2.0.4000" requireReinstallation="True" />
   <package id="Microsoft.CSharp" version="4.6.0" targetFramework="net462" />
-  <package id="NEST" version="7.3.0" targetFramework="net462" />
-  <package id="NEST.JsonNetSerializer" version="7.3.0" targetFramework="net462" />
+  <package id="NEST" version="7.8.1" targetFramework="net462" />
+  <package id="NEST.JsonNetSerializer" version="7.8.1" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
   <package id="NHibernate" version="3.3.1.4000" targetFramework="net451" />
   <package id="System.Buffers" version="4.5.0" targetFramework="net462" />

--- a/Purchasing.Core/packages.config
+++ b/Purchasing.Core/packages.config
@@ -3,9 +3,10 @@
   <package id="AutoMapper" version="3.3.1" targetFramework="net451" />
   <package id="Dapper" version="1.38" targetFramework="net451" />
   <package id="DataAnnotationsExtensions" version="1.1.0.0" targetFramework="net451" />
-  <package id="Elasticsearch.Net" version="7.3.0" targetFramework="net462" />
+  <package id="Elasticsearch.Net" version="7.8.1" targetFramework="net462" />
   <package id="FluentNHibernate" version="1.4.0.0" targetFramework="net451" />
   <package id="Iesi.Collections" version="3.2.0.4000" requireReinstallation="True" />
+  <package id="Microsoft.CSharp" version="4.6.0" targetFramework="net462" />
   <package id="NEST" version="7.3.0" targetFramework="net462" />
   <package id="NEST.JsonNetSerializer" version="7.3.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />

--- a/Purchasing.Jobs.Common/Logging/LogHelper.cs
+++ b/Purchasing.Jobs.Common/Logging/LogHelper.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Configuration;
+using System.Runtime.Remoting.Channels;
 using Serilog;
+using Serilog.Sinks.Elasticsearch;
 
 namespace Purchasing.Jobs.Common.Logging
 {
@@ -11,13 +14,38 @@ namespace Purchasing.Jobs.Common.Logging
         {
             if (_loggingSetup) return; //only setup logging once
 
-            Log.Logger = new LoggerConfiguration().WriteTo.Stackify().CreateLogger();
+            Log.Logger = new LoggerConfiguration()
+                .WriteTo.Stackify()
+                .WriteToElasticSearchCustom()
+                .CreateLogger();
 
             AppDomain.CurrentDomain.UnhandledException +=
                 (sender, eventArgs) =>
                     Log.Error(eventArgs.ExceptionObject as Exception, eventArgs.ExceptionObject.ToString());
 
+            AppDomain.CurrentDomain.ProcessExit += (_, _2) => Log.CloseAndFlush();
+
             _loggingSetup = true;
         }
+
+        public static LoggerConfiguration WriteToElasticSearchCustom(this LoggerConfiguration logConfig)
+        {
+            var esUrl = ConfigurationManager.AppSettings["Stackify.ElasticUrl"];
+
+            // only continue if a valid http url is setup in the config
+            if (esUrl == null || !esUrl.StartsWith("http"))
+            {
+                return logConfig;
+            }
+
+            logConfig.Enrich.WithProperty("Application", ConfigurationManager.AppSettings["Stackify.AppName"]);
+            logConfig.Enrich.WithProperty("AppEnvironment", ConfigurationManager.AppSettings["Stackify.Environment"]);
+
+            return logConfig.WriteTo.Elasticsearch(new ElasticsearchSinkOptions(new Uri(esUrl))
+            {
+                IndexFormat = "aspnet-purchasing-{0:yyyy.MM.dd}"
+            });
+        }
+
     }
 }

--- a/Purchasing.Jobs.Common/Purchasing.Jobs.Common.csproj
+++ b/Purchasing.Jobs.Common/Purchasing.Jobs.Common.csproj
@@ -33,8 +33,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Elmah.Io.Client">
-      <HintPath>..\packages\elmah.io.client.2.0.22\lib\net40\Elmah.Io.Client.dll</HintPath>
+    <Reference Include="Elasticsearch.Net, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\packages\Elasticsearch.Net.7.8.1\lib\net461\Elasticsearch.Net.dll</HintPath>
+    </Reference>
+    <Reference Include="Elmah.Io.Client, Version=2.0.29.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\elmah.io.client.2.0.29\lib\net40\Elmah.Io.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.ServiceLocation">
       <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
@@ -46,16 +49,26 @@
     <Reference Include="Ninject">
       <HintPath>..\packages\Ninject.3.2.2.0\lib\net45-full\Ninject.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.7\lib\net45\Serilog.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.2.8.0\lib\net46\Serilog.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.7\lib\net45\Serilog.FullNetFx.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Serilog.Formatting.Compact, Version=1.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Formatting.Compact.1.0.0\lib\net45\Serilog.Formatting.Compact.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog.Sinks.ElmahIO">
-      <HintPath>..\packages\Serilog.Sinks.ElmahIO.1.5.8\lib\net45\Serilog.Sinks.ElmahIO.dll</HintPath>
+    <Reference Include="Serilog.Formatting.Elasticsearch, Version=0.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Formatting.Elasticsearch.8.4.1\lib\net45\Serilog.Formatting.Elasticsearch.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.Elasticsearch, Version=8.4.1.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.Elasticsearch.8.4.1\lib\net461\Serilog.Sinks.Elasticsearch.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.ElmahIO, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.ElmahIO.2.0.13\lib\net45\Serilog.Sinks.ElmahIO.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.PeriodicBatching, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.PeriodicBatching.2.1.1\lib\net45\Serilog.Sinks.PeriodicBatching.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.Stackify, Version=1.0.12.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.Stackify.1.0.12.0\lib\net45\Serilog.Sinks.Stackify.dll</HintPath>
@@ -66,7 +79,14 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.5.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Purchasing.Jobs.Common/app.config
+++ b/Purchasing.Jobs.Common/app.config
@@ -11,7 +11,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
@@ -24,5 +24,6 @@
     <add key="Stackify.Environment" value="" />
     <add key="Stackify.ProxyServer" value="" />
     <add key="Stackify.ApiKey" value="[External]" />
+    <add key="Stackify.ElasticUrl" value="[External]" />
   </appSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" /></startup></configuration>

--- a/Purchasing.Jobs.Common/packages.config
+++ b/Purchasing.Jobs.Common/packages.config
@@ -1,11 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
-  <package id="elmah.io.client" version="2.0.22" targetFramework="net451" />
+  <package id="Elasticsearch.Net" version="7.8.1" targetFramework="net462" />
+  <package id="elmah.io.client" version="2.0.29" targetFramework="net462" />
+  <package id="Microsoft.CSharp" version="4.6.0" targetFramework="net462" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net451" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net45" />
-  <package id="Serilog" version="1.5.7" targetFramework="net451" />
-  <package id="Serilog.Sinks.ElmahIO" version="1.5.8" targetFramework="net451" />
+  <package id="Serilog" version="2.8.0" targetFramework="net462" />
+  <package id="Serilog.Formatting.Compact" version="1.0.0" targetFramework="net462" />
+  <package id="Serilog.Formatting.Elasticsearch" version="8.4.1" targetFramework="net462" />
+  <package id="Serilog.Sinks.Elasticsearch" version="8.4.1" targetFramework="net462" />
+  <package id="Serilog.Sinks.ElmahIO" version="2.0.13" targetFramework="net462" />
+  <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net462" />
+  <package id="Serilog.Sinks.PeriodicBatching" version="2.1.1" targetFramework="net462" />
   <package id="Serilog.Sinks.Stackify" version="1.0.12.0" targetFramework="net451" />
   <package id="StackifyLib" version="1.12.0.0" targetFramework="net451" />
+  <package id="System.Buffers" version="4.5.0" targetFramework="net462" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net462" />
 </packages>

--- a/Purchasing.Jobs.CreateOrderIndexes/App.config
+++ b/Purchasing.Jobs.CreateOrderIndexes/App.config
@@ -18,7 +18,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
@@ -26,5 +26,6 @@
     <add key="Stackify.AppName" value="Purchasing.Jobs.CreateOrderIndexes" />
     <add key="Stackify.Environment" value="[External]" />
     <add key="Stackify.ApiKey" value="[External]" />
+    <add key="Stackify.ElasticUrl" value="[External]" />
   </appSettings>
 </configuration>

--- a/Purchasing.Jobs.CreateOrderIndexes/Purchasing.Jobs.CreateOrderIndexes.csproj
+++ b/Purchasing.Jobs.CreateOrderIndexes/Purchasing.Jobs.CreateOrderIndexes.csproj
@@ -45,7 +45,7 @@
       <HintPath>..\packages\Dapper.1.38\lib\net45\Dapper.dll</HintPath>
     </Reference>
     <Reference Include="Elasticsearch.Net, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\Elasticsearch.Net.7.3.0\lib\net461\Elasticsearch.Net.dll</HintPath>
+      <HintPath>..\packages\Elasticsearch.Net.7.8.1\lib\net461\Elasticsearch.Net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=1.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -84,13 +84,23 @@
     <Reference Include="Ninject">
       <HintPath>..\packages\Ninject.3.2.2.0\lib\net45-full\Ninject.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.7\lib\net45\Serilog.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.2.8.0\lib\net46\Serilog.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.7\lib\net45\Serilog.FullNetFx.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Serilog.Formatting.Compact, Version=1.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Formatting.Compact.1.0.0\lib\net45\Serilog.Formatting.Compact.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Formatting.Elasticsearch, Version=0.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Formatting.Elasticsearch.8.4.1\lib\net45\Serilog.Formatting.Elasticsearch.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.Elasticsearch, Version=8.4.1.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.Elasticsearch.8.4.1\lib\net461\Serilog.Sinks.Elasticsearch.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.PeriodicBatching, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.PeriodicBatching.2.1.1\lib\net45\Serilog.Sinks.PeriodicBatching.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.Stackify, Version=1.0.12.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.Stackify.1.0.12.0\lib\net45\Serilog.Sinks.Stackify.dll</HintPath>

--- a/Purchasing.Jobs.CreateOrderIndexes/Purchasing.Jobs.CreateOrderIndexes.csproj
+++ b/Purchasing.Jobs.CreateOrderIndexes/Purchasing.Jobs.CreateOrderIndexes.csproj
@@ -76,7 +76,7 @@
       <HintPath>..\packages\WindowsAzure.Storage.4.0.1\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Nest, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\NEST.7.3.0\lib\net461\Nest.dll</HintPath>
+      <HintPath>..\packages\NEST.7.8.1\lib\net461\Nest.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Purchasing.Jobs.CreateOrderIndexes/packages.config
+++ b/Purchasing.Jobs.CreateOrderIndexes/packages.config
@@ -3,9 +3,10 @@
   <package id="AutoMapper" version="3.3.1" targetFramework="net451" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net451" />
   <package id="Dapper" version="1.38" targetFramework="net451" />
-  <package id="Elasticsearch.Net" version="7.3.0" targetFramework="net462" />
+  <package id="Elasticsearch.Net" version="7.8.1" targetFramework="net462" />
   <package id="Microsoft.Azure.WebJobs" version="1.0.1" targetFramework="net451" />
   <package id="Microsoft.Azure.WebJobs.Core" version="1.0.1" targetFramework="net451" />
+  <package id="Microsoft.CSharp" version="4.6.0" targetFramework="net462" />
   <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net451" />
   <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net451" />
   <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net451" />
@@ -15,7 +16,12 @@
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net451" />
   <package id="OctoPack" version="3.0.71" targetFramework="net451" developmentDependency="true" />
-  <package id="Serilog" version="1.5.7" targetFramework="net451" />
+  <package id="Serilog" version="2.8.0" targetFramework="net462" />
+  <package id="Serilog.Formatting.Compact" version="1.0.0" targetFramework="net462" />
+  <package id="Serilog.Formatting.Elasticsearch" version="8.4.1" targetFramework="net462" />
+  <package id="Serilog.Sinks.Elasticsearch" version="8.4.1" targetFramework="net462" />
+  <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net462" />
+  <package id="Serilog.Sinks.PeriodicBatching" version="2.1.1" targetFramework="net462" />
   <package id="Serilog.Sinks.Stackify" version="1.0.12.0" targetFramework="net451" />
   <package id="StackifyLib" version="1.12.0.0" targetFramework="net451" />
   <package id="System.Buffers" version="4.5.0" targetFramework="net462" />

--- a/Purchasing.Jobs.CreateOrderIndexes/packages.config
+++ b/Purchasing.Jobs.CreateOrderIndexes/packages.config
@@ -12,7 +12,7 @@
   <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net451" />
   <package id="Microsoft.Web.WebJobs.Publish" version="1.0.2" targetFramework="net451" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net451" />
-  <package id="NEST" version="7.3.0" targetFramework="net462" />
+  <package id="NEST" version="7.8.1" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net451" />
   <package id="OctoPack" version="3.0.71" targetFramework="net451" developmentDependency="true" />

--- a/Purchasing.Jobs.DailyEmailNotifications/App.config
+++ b/Purchasing.Jobs.DailyEmailNotifications/App.config
@@ -18,7 +18,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
@@ -26,5 +26,6 @@
     <add key="Stackify.AppName" value="Purchasing.Jobs.DailyEmailNotifications" />
     <add key="Stackify.Environment" value="[External]" />
     <add key="Stackify.ApiKey" value="[External]" />
+    <add key="Stackify.ElasticUrl" value="[External]" />
   </appSettings>
 </configuration>

--- a/Purchasing.Jobs.DailyEmailNotifications/Purchasing.Jobs.DailyEmailNotifications.csproj
+++ b/Purchasing.Jobs.DailyEmailNotifications/Purchasing.Jobs.DailyEmailNotifications.csproj
@@ -35,9 +35,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Elmah.Io.Client, Version=2.0.22.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\elmah.io.client.2.0.22\lib\net40\Elmah.Io.Client.dll</HintPath>
+    <Reference Include="Elasticsearch.Net, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\packages\Elasticsearch.Net.7.8.1\lib\net461\Elasticsearch.Net.dll</HintPath>
+    </Reference>
+    <Reference Include="Elmah.Io.Client, Version=2.0.29.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\elmah.io.client.2.0.29\lib\net40\Elmah.Io.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs">
       <HintPath>..\packages\Microsoft.Azure.WebJobs.Core.1.0.1\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
@@ -68,16 +70,26 @@
     <Reference Include="Ninject">
       <HintPath>..\packages\Ninject.3.2.2.0\lib\net45-full\Ninject.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.7\lib\net45\Serilog.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.2.8.0\lib\net46\Serilog.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.7\lib\net45\Serilog.FullNetFx.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Serilog.Formatting.Compact, Version=1.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Formatting.Compact.1.0.0\lib\net45\Serilog.Formatting.Compact.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog.Sinks.ElmahIO">
-      <HintPath>..\packages\Serilog.Sinks.ElmahIO.1.5.8\lib\net45\Serilog.Sinks.ElmahIO.dll</HintPath>
+    <Reference Include="Serilog.Formatting.Elasticsearch, Version=0.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Formatting.Elasticsearch.8.4.1\lib\net45\Serilog.Formatting.Elasticsearch.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.Elasticsearch, Version=8.4.1.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.Elasticsearch.8.4.1\lib\net461\Serilog.Sinks.Elasticsearch.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.ElmahIO, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.ElmahIO.2.0.13\lib\net45\Serilog.Sinks.ElmahIO.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.PeriodicBatching, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.PeriodicBatching.2.1.1\lib\net45\Serilog.Sinks.PeriodicBatching.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.Stackify, Version=1.0.12.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.Stackify.1.0.12.0\lib\net45\Serilog.Sinks.Stackify.dll</HintPath>
@@ -88,7 +100,13 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.5.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Spatial, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Spatial.5.6.0\lib\net40\System.Spatial.dll</HintPath>
     </Reference>

--- a/Purchasing.Jobs.DailyEmailNotifications/packages.config
+++ b/Purchasing.Jobs.DailyEmailNotifications/packages.config
@@ -1,8 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="elmah.io.client" version="2.0.22" targetFramework="net451" />
+  <package id="Elasticsearch.Net" version="7.8.1" targetFramework="net462" />
+  <package id="elmah.io.client" version="2.0.29" targetFramework="net462" />
   <package id="Microsoft.Azure.WebJobs" version="1.0.1" targetFramework="net451" />
   <package id="Microsoft.Azure.WebJobs.Core" version="1.0.1" targetFramework="net451" />
+  <package id="Microsoft.CSharp" version="4.6.0" targetFramework="net462" />
   <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net451" />
   <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net451" />
   <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net451" />
@@ -11,10 +13,17 @@
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net451" />
   <package id="OctoPack" version="3.0.71" targetFramework="net451" developmentDependency="true" />
-  <package id="Serilog" version="1.5.7" targetFramework="net451" />
-  <package id="Serilog.Sinks.ElmahIO" version="1.5.8" targetFramework="net451" />
+  <package id="Serilog" version="2.8.0" targetFramework="net462" />
+  <package id="Serilog.Formatting.Compact" version="1.0.0" targetFramework="net462" />
+  <package id="Serilog.Formatting.Elasticsearch" version="8.4.1" targetFramework="net462" />
+  <package id="Serilog.Sinks.Elasticsearch" version="8.4.1" targetFramework="net462" />
+  <package id="Serilog.Sinks.ElmahIO" version="2.0.13" targetFramework="net462" />
+  <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net462" />
+  <package id="Serilog.Sinks.PeriodicBatching" version="2.1.1" targetFramework="net462" />
   <package id="Serilog.Sinks.Stackify" version="1.0.12.0" targetFramework="net451" />
   <package id="StackifyLib" version="1.12.0.0" targetFramework="net451" />
+  <package id="System.Buffers" version="4.5.0" targetFramework="net462" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net462" />
   <package id="System.Spatial" version="5.6.0" targetFramework="net451" />
   <package id="WindowsAzure.Storage" version="4.0.1" targetFramework="net451" />
 </packages>

--- a/Purchasing.Jobs.EmailNotifications/App.config
+++ b/Purchasing.Jobs.EmailNotifications/App.config
@@ -22,7 +22,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Purchasing.Jobs.EmailNotifications/Purchasing.Jobs.EmailNotifications.csproj
+++ b/Purchasing.Jobs.EmailNotifications/Purchasing.Jobs.EmailNotifications.csproj
@@ -35,9 +35,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Elmah.Io.Client, Version=2.0.22.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\elmah.io.client.2.0.22\lib\net40\Elmah.Io.Client.dll</HintPath>
+    <Reference Include="Elasticsearch.Net, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\packages\Elasticsearch.Net.7.8.1\lib\net461\Elasticsearch.Net.dll</HintPath>
+    </Reference>
+    <Reference Include="Elmah.Io.Client, Version=2.0.29.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\elmah.io.client.2.0.29\lib\net40\Elmah.Io.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs">
       <HintPath>..\packages\Microsoft.Azure.WebJobs.Core.1.0.1\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
@@ -69,17 +71,26 @@
     <Reference Include="Ninject">
       <HintPath>..\packages\Ninject.3.2.2.0\lib\net45-full\Ninject.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.7\lib\net45\Serilog.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.2.8.0\lib\net46\Serilog.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.7\lib\net45\Serilog.FullNetFx.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Serilog.Formatting.Compact, Version=1.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Formatting.Compact.1.0.0\lib\net45\Serilog.Formatting.Compact.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog.Sinks.ElmahIO, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Serilog.Sinks.ElmahIO.1.5.8\lib\net45\Serilog.Sinks.ElmahIO.dll</HintPath>
+    <Reference Include="Serilog.Formatting.Elasticsearch, Version=0.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Formatting.Elasticsearch.8.4.1\lib\net45\Serilog.Formatting.Elasticsearch.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.Elasticsearch, Version=8.4.1.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.Elasticsearch.8.4.1\lib\net461\Serilog.Sinks.Elasticsearch.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.ElmahIO, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.ElmahIO.2.0.13\lib\net45\Serilog.Sinks.ElmahIO.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.PeriodicBatching, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.PeriodicBatching.2.1.1\lib\net45\Serilog.Sinks.PeriodicBatching.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.Stackify, Version=1.0.12.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.Stackify.1.0.12.0\lib\net45\Serilog.Sinks.Stackify.dll</HintPath>
@@ -90,7 +101,13 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.5.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Spatial, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Spatial.5.6.0\lib\net40\System.Spatial.dll</HintPath>
     </Reference>

--- a/Purchasing.Jobs.EmailNotifications/packages.config
+++ b/Purchasing.Jobs.EmailNotifications/packages.config
@@ -1,8 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="elmah.io.client" version="2.0.22" targetFramework="net451" />
+  <package id="Elasticsearch.Net" version="7.8.1" targetFramework="net462" />
+  <package id="elmah.io.client" version="2.0.29" targetFramework="net462" />
   <package id="Microsoft.Azure.WebJobs" version="1.0.1" targetFramework="net451" />
   <package id="Microsoft.Azure.WebJobs.Core" version="1.0.1" targetFramework="net451" />
+  <package id="Microsoft.CSharp" version="4.6.0" targetFramework="net462" />
   <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net451" />
   <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net451" />
   <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net451" />
@@ -11,10 +13,17 @@
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net451" />
   <package id="OctoPack" version="3.0.71" targetFramework="net451" developmentDependency="true" />
-  <package id="Serilog" version="1.5.7" targetFramework="net451" />
-  <package id="Serilog.Sinks.ElmahIO" version="1.5.8" targetFramework="net451" />
+  <package id="Serilog" version="2.8.0" targetFramework="net462" />
+  <package id="Serilog.Formatting.Compact" version="1.0.0" targetFramework="net462" />
+  <package id="Serilog.Formatting.Elasticsearch" version="8.4.1" targetFramework="net462" />
+  <package id="Serilog.Sinks.Elasticsearch" version="8.4.1" targetFramework="net462" />
+  <package id="Serilog.Sinks.ElmahIO" version="2.0.13" targetFramework="net462" />
+  <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net462" />
+  <package id="Serilog.Sinks.PeriodicBatching" version="2.1.1" targetFramework="net462" />
   <package id="Serilog.Sinks.Stackify" version="1.0.12.0" targetFramework="net451" />
   <package id="StackifyLib" version="1.12.0.0" targetFramework="net451" />
+  <package id="System.Buffers" version="4.5.0" targetFramework="net462" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net462" />
   <package id="System.Spatial" version="5.6.0" targetFramework="net451" />
   <package id="WindowsAzure.Storage" version="4.0.1" targetFramework="net451" />
 </packages>

--- a/Purchasing.Jobs.NightlySync/App.config
+++ b/Purchasing.Jobs.NightlySync/App.config
@@ -18,7 +18,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
@@ -26,5 +26,6 @@
     <add key="Stackify.AppName" value="Purchasing.Jobs.NightlySync" />
     <add key="Stackify.Environment" value="[External]" />
     <add key="Stackify.ApiKey" value="[External]" />
+    <add key="Stackify.ElasticUrl" value="[External]" />
   </appSettings>
 </configuration>

--- a/Purchasing.Jobs.NightlySync/Purchasing.Jobs.NightlySync.csproj
+++ b/Purchasing.Jobs.NightlySync/Purchasing.Jobs.NightlySync.csproj
@@ -39,9 +39,11 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Dapper.1.38\lib\net45\Dapper.dll</HintPath>
     </Reference>
-    <Reference Include="Elmah.Io.Client, Version=2.0.22.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\elmah.io.client.2.0.22\lib\net40\Elmah.Io.Client.dll</HintPath>
+    <Reference Include="Elasticsearch.Net, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\packages\Elasticsearch.Net.7.8.1\lib\net461\Elasticsearch.Net.dll</HintPath>
+    </Reference>
+    <Reference Include="Elmah.Io.Client, Version=2.0.29.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\elmah.io.client.2.0.29\lib\net40\Elmah.Io.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs">
       <HintPath>..\packages\Microsoft.Azure.WebJobs.Core.1.0.1\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
@@ -73,17 +75,26 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Ninject.3.2.2.0\lib\net45-full\Ninject.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.7\lib\net45\Serilog.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.2.8.0\lib\net46\Serilog.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.7\lib\net45\Serilog.FullNetFx.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Serilog.Formatting.Compact, Version=1.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Formatting.Compact.1.0.0\lib\net45\Serilog.Formatting.Compact.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog.Sinks.ElmahIO, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Serilog.Sinks.ElmahIO.1.5.8\lib\net45\Serilog.Sinks.ElmahIO.dll</HintPath>
+    <Reference Include="Serilog.Formatting.Elasticsearch, Version=0.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Formatting.Elasticsearch.8.4.1\lib\net45\Serilog.Formatting.Elasticsearch.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.Elasticsearch, Version=8.4.1.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.Elasticsearch.8.4.1\lib\net461\Serilog.Sinks.Elasticsearch.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.ElmahIO, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.ElmahIO.2.0.13\lib\net45\Serilog.Sinks.ElmahIO.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.PeriodicBatching, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.PeriodicBatching.2.1.1\lib\net45\Serilog.Sinks.PeriodicBatching.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.Stackify, Version=1.0.12.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.Stackify.1.0.12.0\lib\net45\Serilog.Sinks.Stackify.dll</HintPath>
@@ -94,7 +105,13 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.5.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Spatial, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Spatial.5.6.0\lib\net40\System.Spatial.dll</HintPath>
     </Reference>

--- a/Purchasing.Jobs.NightlySync/packages.config
+++ b/Purchasing.Jobs.NightlySync/packages.config
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Dapper" version="1.38" targetFramework="net451" />
-  <package id="elmah.io.client" version="2.0.22" targetFramework="net451" />
+  <package id="Elasticsearch.Net" version="7.8.1" targetFramework="net462" />
+  <package id="elmah.io.client" version="2.0.29" targetFramework="net462" />
   <package id="Microsoft.Azure.WebJobs" version="1.0.1" targetFramework="net451" />
   <package id="Microsoft.Azure.WebJobs.Core" version="1.0.1" targetFramework="net451" />
+  <package id="Microsoft.CSharp" version="4.6.0" targetFramework="net462" />
   <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net451" />
   <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net451" />
   <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net451" />
@@ -12,10 +14,17 @@
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net451" />
   <package id="OctoPack" version="3.0.71" targetFramework="net451" developmentDependency="true" />
-  <package id="Serilog" version="1.5.7" targetFramework="net451" />
-  <package id="Serilog.Sinks.ElmahIO" version="1.5.8" targetFramework="net451" />
+  <package id="Serilog" version="2.8.0" targetFramework="net462" />
+  <package id="Serilog.Formatting.Compact" version="1.0.0" targetFramework="net462" />
+  <package id="Serilog.Formatting.Elasticsearch" version="8.4.1" targetFramework="net462" />
+  <package id="Serilog.Sinks.Elasticsearch" version="8.4.1" targetFramework="net462" />
+  <package id="Serilog.Sinks.ElmahIO" version="2.0.13" targetFramework="net462" />
+  <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net462" />
+  <package id="Serilog.Sinks.PeriodicBatching" version="2.1.1" targetFramework="net462" />
   <package id="Serilog.Sinks.Stackify" version="1.0.12.0" targetFramework="net451" />
   <package id="StackifyLib" version="1.12.0.0" targetFramework="net451" />
+  <package id="System.Buffers" version="4.5.0" targetFramework="net462" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net462" />
   <package id="System.Spatial" version="5.6.0" targetFramework="net451" />
   <package id="WindowsAzure.Storage" version="4.0.1" targetFramework="net451" />
 </packages>

--- a/Purchasing.Jobs.NotificationsCommon/Purchasing.Jobs.NotificationsCommon.csproj
+++ b/Purchasing.Jobs.NotificationsCommon/Purchasing.Jobs.NotificationsCommon.csproj
@@ -54,13 +54,8 @@
     <Reference Include="SendGridMail">
       <HintPath>..\packages\Sendgrid.5.0.0\lib\SendGridMail.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.7\lib\net45\Serilog.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.7\lib\net45\Serilog.FullNetFx.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.2.8.0\lib\net46\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="SparkPost, Version=1.0.2.24239, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SparkPost.1.0.7\lib\net45\SparkPost.dll</HintPath>

--- a/Purchasing.Jobs.NotificationsCommon/app.config
+++ b/Purchasing.Jobs.NotificationsCommon/app.config
@@ -12,7 +12,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
@@ -21,5 +21,6 @@
     <add key="Stackify.Environment" value="" />
     <add key="Stackify.ProxyServer" value="" />
     <add key="Stackify.ApiKey" value="" />
+    <add key="Stackify.ElasticUrl" value="" />
   </appSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" /></startup></configuration>

--- a/Purchasing.Jobs.NotificationsCommon/packages.config
+++ b/Purchasing.Jobs.NotificationsCommon/packages.config
@@ -7,7 +7,7 @@
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
   <package id="Sendgrid" version="5.0.0" targetFramework="net451" />
   <package id="SendGrid.SmtpApi" version="1.1.3" targetFramework="net451" />
-  <package id="Serilog" version="1.5.7" targetFramework="net451" />
+  <package id="Serilog" version="2.8.0" targetFramework="net462" />
   <package id="SparkPost" version="1.0.7" targetFramework="net451" />
   <package id="StackifyLib" version="1.12.0.0" targetFramework="net451" />
 </packages>

--- a/Purchasing.Jobs.UpdateLookupIndexes/App.config
+++ b/Purchasing.Jobs.UpdateLookupIndexes/App.config
@@ -18,7 +18,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
@@ -26,5 +26,6 @@
     <add key="Stackify.AppName" value="Purchasing.Jobs.UpdateLookupIndexes" />
     <add key="Stackify.Environment" value="[External]" />
     <add key="Stackify.ApiKey" value="[External]" />
+    <add key="Stackify.ElasticUrl" value="[External]" />
   </appSettings>
 </configuration>

--- a/Purchasing.Jobs.UpdateLookupIndexes/Purchasing.Jobs.UpdateLookupIndexes.csproj
+++ b/Purchasing.Jobs.UpdateLookupIndexes/Purchasing.Jobs.UpdateLookupIndexes.csproj
@@ -60,7 +60,7 @@
       <HintPath>..\packages\Dapper.1.38\lib\net45\Dapper.dll</HintPath>
     </Reference>
     <Reference Include="Elasticsearch.Net, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\Elasticsearch.Net.7.3.0\lib\net461\Elasticsearch.Net.dll</HintPath>
+      <HintPath>..\packages\Elasticsearch.Net.7.8.1\lib\net461\Elasticsearch.Net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=1.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -99,13 +99,23 @@
     <Reference Include="Ninject">
       <HintPath>..\packages\Ninject.3.2.2.0\lib\net45-full\Ninject.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.7\lib\net45\Serilog.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.2.8.0\lib\net46\Serilog.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.7\lib\net45\Serilog.FullNetFx.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Serilog.Formatting.Compact, Version=1.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Formatting.Compact.1.0.0\lib\net45\Serilog.Formatting.Compact.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Formatting.Elasticsearch, Version=0.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Formatting.Elasticsearch.8.4.1\lib\net45\Serilog.Formatting.Elasticsearch.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.Elasticsearch, Version=8.4.1.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.Elasticsearch.8.4.1\lib\net461\Serilog.Sinks.Elasticsearch.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.PeriodicBatching, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.PeriodicBatching.2.1.1\lib\net45\Serilog.Sinks.PeriodicBatching.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.Stackify, Version=1.0.12.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.Stackify.1.0.12.0\lib\net45\Serilog.Sinks.Stackify.dll</HintPath>

--- a/Purchasing.Jobs.UpdateLookupIndexes/Purchasing.Jobs.UpdateLookupIndexes.csproj
+++ b/Purchasing.Jobs.UpdateLookupIndexes/Purchasing.Jobs.UpdateLookupIndexes.csproj
@@ -91,7 +91,7 @@
       <HintPath>..\packages\WindowsAzure.Storage.4.0.1\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Nest, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\NEST.7.3.0\lib\net461\Nest.dll</HintPath>
+      <HintPath>..\packages\NEST.7.8.1\lib\net461\Nest.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Purchasing.Jobs.UpdateLookupIndexes/packages.config
+++ b/Purchasing.Jobs.UpdateLookupIndexes/packages.config
@@ -3,9 +3,10 @@
   <package id="AutoMapper" version="3.3.1" targetFramework="net451" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net451" />
   <package id="Dapper" version="1.38" targetFramework="net451" />
-  <package id="Elasticsearch.Net" version="7.3.0" targetFramework="net462" />
+  <package id="Elasticsearch.Net" version="7.8.1" targetFramework="net462" />
   <package id="Microsoft.Azure.WebJobs" version="1.0.1" targetFramework="net451" />
   <package id="Microsoft.Azure.WebJobs.Core" version="1.0.1" targetFramework="net451" />
+  <package id="Microsoft.CSharp" version="4.6.0" targetFramework="net462" />
   <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net451" />
   <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net451" />
   <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net451" />
@@ -15,7 +16,12 @@
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net451" />
   <package id="OctoPack" version="3.0.71" targetFramework="net451" developmentDependency="true" />
-  <package id="Serilog" version="1.5.7" targetFramework="net451" />
+  <package id="Serilog" version="2.8.0" targetFramework="net462" />
+  <package id="Serilog.Formatting.Compact" version="1.0.0" targetFramework="net462" />
+  <package id="Serilog.Formatting.Elasticsearch" version="8.4.1" targetFramework="net462" />
+  <package id="Serilog.Sinks.Elasticsearch" version="8.4.1" targetFramework="net462" />
+  <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net462" />
+  <package id="Serilog.Sinks.PeriodicBatching" version="2.1.1" targetFramework="net462" />
   <package id="Serilog.Sinks.Stackify" version="1.0.12.0" targetFramework="net451" />
   <package id="StackifyLib" version="1.12.0.0" targetFramework="net451" />
   <package id="System.Buffers" version="4.5.0" targetFramework="net462" />

--- a/Purchasing.Jobs.UpdateLookupIndexes/packages.config
+++ b/Purchasing.Jobs.UpdateLookupIndexes/packages.config
@@ -12,7 +12,7 @@
   <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net451" />
   <package id="Microsoft.Web.WebJobs.Publish" version="1.0.2" targetFramework="net451" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net451" />
-  <package id="NEST" version="7.3.0" targetFramework="net462" />
+  <package id="NEST" version="7.8.1" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net451" />
   <package id="OctoPack" version="3.0.71" targetFramework="net451" developmentDependency="true" />

--- a/Purchasing.Jobs.UpdateOrderIndexes/App.config
+++ b/Purchasing.Jobs.UpdateOrderIndexes/App.config
@@ -18,7 +18,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
@@ -26,5 +26,6 @@
     <add key="Stackify.AppName" value="Purchasing.Jobs.UpdateOrderIndexes" />
     <add key="Stackify.Environment" value="[External]" />
     <add key="Stackify.ApiKey" value="[External]" />
+    <add key="Stackify.ElasticUrl" value="[External]" />
   </appSettings>
 </configuration>

--- a/Purchasing.Jobs.UpdateOrderIndexes/Purchasing.Jobs.UpdateOrderIndexes.csproj
+++ b/Purchasing.Jobs.UpdateOrderIndexes/Purchasing.Jobs.UpdateOrderIndexes.csproj
@@ -47,7 +47,7 @@
       <HintPath>..\packages\Dapper.1.38\lib\net45\Dapper.dll</HintPath>
     </Reference>
     <Reference Include="Elasticsearch.Net, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\Elasticsearch.Net.7.3.0\lib\net461\Elasticsearch.Net.dll</HintPath>
+      <HintPath>..\packages\Elasticsearch.Net.7.8.1\lib\net461\Elasticsearch.Net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=1.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -87,13 +87,23 @@
     <Reference Include="Ninject">
       <HintPath>..\packages\Ninject.3.2.2.0\lib\net45-full\Ninject.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.7\lib\net45\Serilog.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.2.8.0\lib\net46\Serilog.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.7\lib\net45\Serilog.FullNetFx.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Serilog.Formatting.Compact, Version=1.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Formatting.Compact.1.0.0\lib\net45\Serilog.Formatting.Compact.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Formatting.Elasticsearch, Version=0.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Formatting.Elasticsearch.8.4.1\lib\net45\Serilog.Formatting.Elasticsearch.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.Elasticsearch, Version=8.4.1.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.Elasticsearch.8.4.1\lib\net461\Serilog.Sinks.Elasticsearch.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.PeriodicBatching, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.PeriodicBatching.2.1.1\lib\net45\Serilog.Sinks.PeriodicBatching.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.Stackify, Version=1.0.12.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.Stackify.1.0.12.0\lib\net45\Serilog.Sinks.Stackify.dll</HintPath>

--- a/Purchasing.Jobs.UpdateOrderIndexes/Purchasing.Jobs.UpdateOrderIndexes.csproj
+++ b/Purchasing.Jobs.UpdateOrderIndexes/Purchasing.Jobs.UpdateOrderIndexes.csproj
@@ -79,7 +79,7 @@
       <HintPath>..\packages\WindowsAzure.Storage.4.0.1\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Nest, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\NEST.7.3.0\lib\net461\Nest.dll</HintPath>
+      <HintPath>..\packages\NEST.7.8.1\lib\net461\Nest.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Purchasing.Jobs.UpdateOrderIndexes/packages.config
+++ b/Purchasing.Jobs.UpdateOrderIndexes/packages.config
@@ -3,9 +3,10 @@
   <package id="AutoMapper" version="3.3.1" targetFramework="net451" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net451" />
   <package id="Dapper" version="1.38" targetFramework="net451" />
-  <package id="Elasticsearch.Net" version="7.3.0" targetFramework="net462" />
+  <package id="Elasticsearch.Net" version="7.8.1" targetFramework="net462" />
   <package id="Microsoft.Azure.WebJobs" version="1.0.1" targetFramework="net451" />
   <package id="Microsoft.Azure.WebJobs.Core" version="1.0.1" targetFramework="net451" />
+  <package id="Microsoft.CSharp" version="4.6.0" targetFramework="net462" />
   <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net451" />
   <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net451" />
   <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net451" />
@@ -15,7 +16,12 @@
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net451" />
   <package id="OctoPack" version="3.0.71" targetFramework="net451" developmentDependency="true" />
-  <package id="Serilog" version="1.5.7" targetFramework="net451" />
+  <package id="Serilog" version="2.8.0" targetFramework="net462" />
+  <package id="Serilog.Formatting.Compact" version="1.0.0" targetFramework="net462" />
+  <package id="Serilog.Formatting.Elasticsearch" version="8.4.1" targetFramework="net462" />
+  <package id="Serilog.Sinks.Elasticsearch" version="8.4.1" targetFramework="net462" />
+  <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net462" />
+  <package id="Serilog.Sinks.PeriodicBatching" version="2.1.1" targetFramework="net462" />
   <package id="Serilog.Sinks.Stackify" version="1.0.12.0" targetFramework="net451" />
   <package id="StackifyLib" version="1.12.0.0" targetFramework="net451" />
   <package id="System.Buffers" version="4.5.0" targetFramework="net462" />

--- a/Purchasing.Jobs.UpdateOrderIndexes/packages.config
+++ b/Purchasing.Jobs.UpdateOrderIndexes/packages.config
@@ -12,7 +12,7 @@
   <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net451" />
   <package id="Microsoft.Web.WebJobs.Publish" version="1.0.2" targetFramework="net451" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net451" />
-  <package id="NEST" version="7.3.0" targetFramework="net462" />
+  <package id="NEST" version="7.8.1" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net451" />
   <package id="OctoPack" version="3.0.71" targetFramework="net451" developmentDependency="true" />

--- a/Purchasing.Mvc/App_Start/LogConfig.cs
+++ b/Purchasing.Mvc/App_Start/LogConfig.cs
@@ -44,8 +44,6 @@ namespace Purchasing.Mvc
                 return logConfig;
             }
 
-            var environment = ConfigurationManager.AppSettings["Stackify.Environment"];
-
             logConfig.Enrich.WithProperty("Application", ConfigurationManager.AppSettings["Stackify.AppName"]);
             logConfig.Enrich.WithProperty("AppEnvironment", ConfigurationManager.AppSettings["Stackify.Environment"]);
             logConfig.Enrich.WithClientIp();

--- a/Purchasing.Mvc/Purchasing.Mvc.csproj
+++ b/Purchasing.Mvc/Purchasing.Mvc.csproj
@@ -76,7 +76,7 @@
       <HintPath>..\packages\DataAnnotationsExtensions.MVC3.1.1.0.0\lib\NETFramework40\DataAnnotationsExtensions.ClientValidation.dll</HintPath>
     </Reference>
     <Reference Include="Elasticsearch.Net, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\Elasticsearch.Net.7.3.0\lib\net461\Elasticsearch.Net.dll</HintPath>
+      <HintPath>..\packages\Elasticsearch.Net.7.8.1\lib\net461\Elasticsearch.Net.dll</HintPath>
     </Reference>
     <Reference Include="Elmah">
       <HintPath>..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
@@ -171,13 +171,26 @@
     <Reference Include="SendGridMail">
       <HintPath>..\packages\Sendgrid.5.0.0\lib\SendGridMail.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.7\lib\net45\Serilog.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.2.8.0\lib\net46\Serilog.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.7\lib\net45\Serilog.FullNetFx.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Serilog.Enrichers.ClientInfo, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Enrichers.ClientInfo.1.1.3\lib\net452\Serilog.Enrichers.ClientInfo.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Formatting.Compact, Version=1.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Formatting.Compact.1.0.0\lib\net45\Serilog.Formatting.Compact.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Formatting.Elasticsearch, Version=0.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Formatting.Elasticsearch.8.4.1\lib\net45\Serilog.Formatting.Elasticsearch.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.Elasticsearch, Version=8.4.1.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.Elasticsearch.8.4.1\lib\net461\Serilog.Sinks.Elasticsearch.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.PeriodicBatching, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.PeriodicBatching.2.1.1\lib\net45\Serilog.Sinks.PeriodicBatching.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.Stackify, Version=1.0.12.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.Stackify.1.0.12.0\lib\net45\Serilog.Sinks.Stackify.dll</HintPath>

--- a/Purchasing.Mvc/Purchasing.Mvc.csproj
+++ b/Purchasing.Mvc/Purchasing.Mvc.csproj
@@ -145,7 +145,7 @@
       <HintPath>..\packages\MvcContrib.Mvc3.FluentHtml-ci.3.0.100.0\lib\MvcContrib.FluentHtml.dll</HintPath>
     </Reference>
     <Reference Include="Nest, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\NEST.7.3.0\lib\net461\Nest.dll</HintPath>
+      <HintPath>..\packages\NEST.7.8.1\lib\net461\Nest.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Purchasing.Mvc/Web.config
+++ b/Purchasing.Mvc/Web.config
@@ -15,7 +15,7 @@
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
     <add key="AfsUrl" value="https://kfs-test.ucdavis.edu/kfs-stg/remoting/purchaseDocumentsInterfaceServiceSOAP" />
-    <add key="AfsLookupUrl" value="https://kfs.ucdavis.edu/kfs-prd"/> <!-- This will be changing to https://kfs-uat.ucdavis.edu/fin for testing. probably just the fin for production -->
+    <add key="AfsLookupUrl" value="https://kfs.ucdavis.edu/kfs-prd" /> <!-- This will be changing to https://kfs-uat.ucdavis.edu/fin for testing. probably just the fin for production -->
     <add key="AfsRoleUrl" value="http://kfs-test.ucdavis.edu/kfs-stg/remoting/financialSystemRoleServiceSOAP" />
     <add key="AfsToken" value="stage" />
     <add key="Stackify.AppName" value="Purchasing" />
@@ -23,6 +23,7 @@
     <add key="Stackify.ApiKey" value="[External]" />
     <add key="PersonLookupUrl" value="http://directory.ucdavis.edu/search/directory_results.shtml?filter=" />
     <add key="IetWsKey" value="[External]" />
+    <add key="Stackify.ElasticUrl" value="[External]" />
   </appSettings>
   <connectionStrings>
     <add name="MainDB" connectionString="data source=.\SQLExpress;Initial Catalog=PrePurchasing;Integrated Security=true;" providerName="System.Data.SqlClient" />
@@ -95,7 +96,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -104,6 +105,10 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Elasticsearch.Net" publicKeyToken="96c599bbe3e70f5d" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Purchasing.Mvc/packages.config
+++ b/Purchasing.Mvc/packages.config
@@ -37,7 +37,7 @@
   <package id="MiniProfiler" version="3.1.1.140" targetFramework="net451" />
   <package id="Modernizr" version="2.8.3" targetFramework="net45" />
   <package id="MvcContrib.Mvc3.FluentHtml-ci" version="3.0.100.0" targetFramework="net45" />
-  <package id="NEST" version="7.3.0" targetFramework="net462" />
+  <package id="NEST" version="7.8.1" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
   <package id="NHibernate" version="3.3.1.4000" targetFramework="net45" />
   <package id="NPOI" version="2.0.6" targetFramework="net451" />

--- a/Purchasing.Mvc/packages.config
+++ b/Purchasing.Mvc/packages.config
@@ -10,7 +10,7 @@
   <package id="Dapper" version="1.38" targetFramework="net451" />
   <package id="DataAnnotationsExtensions" version="1.1.0.0" targetFramework="net45" />
   <package id="DataAnnotationsExtensions.MVC3" version="1.1.0.0" targetFramework="net45" />
-  <package id="Elasticsearch.Net" version="7.3.0" targetFramework="net462" />
+  <package id="Elasticsearch.Net" version="7.8.1" targetFramework="net462" />
   <package id="elmah" version="1.2.2" targetFramework="net45" />
   <package id="elmah.corelibrary" version="1.2.2" targetFramework="net45" />
   <package id="FluentNHibernate" version="1.4.0.0" targetFramework="net45" />
@@ -26,6 +26,7 @@
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.2" targetFramework="net45" />
   <package id="Microsoft.Azure.ActiveDirectory.GraphClient" version="2.1.1" targetFramework="net452" />
+  <package id="Microsoft.CSharp" version="4.6.0" targetFramework="net462" />
   <package id="Microsoft.Data.Edm" version="5.8.1" targetFramework="net452" />
   <package id="Microsoft.Data.OData" version="5.8.1" targetFramework="net452" />
   <package id="Microsoft.Data.Services.Client" version="5.8.1" targetFramework="net452" />
@@ -44,7 +45,13 @@
   <package id="Respond" version="1.4.2" targetFramework="net45" />
   <package id="Sendgrid" version="5.0.0" targetFramework="net451" />
   <package id="SendGrid.SmtpApi" version="1.1.3" targetFramework="net451" />
-  <package id="Serilog" version="1.5.7" targetFramework="net451" />
+  <package id="Serilog" version="2.8.0" targetFramework="net462" />
+  <package id="Serilog.Enrichers.ClientInfo" version="1.1.3" targetFramework="net462" />
+  <package id="Serilog.Formatting.Compact" version="1.0.0" targetFramework="net462" />
+  <package id="Serilog.Formatting.Elasticsearch" version="8.4.1" targetFramework="net462" />
+  <package id="Serilog.Sinks.Elasticsearch" version="8.4.1" targetFramework="net462" />
+  <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net462" />
+  <package id="Serilog.Sinks.PeriodicBatching" version="2.1.1" targetFramework="net462" />
   <package id="Serilog.Sinks.Stackify" version="1.0.12.0" targetFramework="net451" />
   <package id="SerilogWeb.Classic" version="2.0.6" targetFramework="net451" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net451" />

--- a/Purchasing.Tests/App.config
+++ b/Purchasing.Tests/App.config
@@ -75,7 +75,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Purchasing.WS/Purchasing.WS.csproj
+++ b/Purchasing.WS/Purchasing.WS.csproj
@@ -122,13 +122,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\WindowsAzure.Storage.2.1.0.3\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.7\lib\net45\Serilog.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.7\lib\net45\Serilog.FullNetFx.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.2.8.0\lib\net46\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/Purchasing.WS/app.config
+++ b/Purchasing.WS/app.config
@@ -42,5 +42,6 @@
     <add key="Stackify.Environment" value="" />
     <add key="Stackify.ProxyServer" value="" />
     <add key="Stackify.ApiKey" value="[External]" />
+    <add key="Stackify.ElasticUrl" value="[External]" />
   </appSettings>
 </configuration>

--- a/Purchasing.WS/packages.config
+++ b/Purchasing.WS/packages.config
@@ -9,7 +9,7 @@
   <package id="Microsoft.Data.OData" version="5.2.0" targetFramework="net40" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net40" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net451" />
-  <package id="Serilog" version="1.5.7" targetFramework="net451" />
+  <package id="Serilog" version="2.8.0" targetFramework="net462" />
   <package id="System.Spatial" version="5.2.0" targetFramework="net40" />
   <package id="UcdArch" version="5.1.0.145" targetFramework="net451" />
   <package id="WindowsAzure.Storage" version="2.1.0.3" targetFramework="net40" />


### PR DESCRIPTION
In spite of Serilog v-latest being split into several nuget packages, it ended up being easier to upgrade than install an older version of elastic sink.

Even though `Purchasing.Jobs.Common` is referenced by all the job projects, they still seemed to want nuget dependencies to be explicitly declared.

I temporarily commented out the logic in one of the job apps in order to to verify logging without, you know, inadvertently triggering some change in prod. 