### PR TITLE
remove stackify logging from jobs and web

### DIFF
--- a/Purchasing.Jobs.Common/Logging/LogHelper.cs
+++ b/Purchasing.Jobs.Common/Logging/LogHelper.cs
@@ -15,7 +15,6 @@ namespace Purchasing.Jobs.Common.Logging
             if (_loggingSetup) return; //only setup logging once
 
             Log.Logger = new LoggerConfiguration()
-                .WriteTo.Stackify()
                 .WriteToElasticSearchCustom()
                 .CreateLogger();
 

--- a/Purchasing.Mvc/App_Start/LogConfig.cs
+++ b/Purchasing.Mvc/App_Start/LogConfig.cs
@@ -23,7 +23,6 @@ namespace Purchasing.Mvc
             if (_loggingSetup) return; //only setup logging once
 
             Log.Logger = new LoggerConfiguration()
-                .WriteTo.Stackify()
                 .WriteToElasticSearchCustom()
                 .Enrich.With<HttpSessionIdEnricher>()
                 .Enrich.With<UserNameEnricher>()


### PR DESCRIPTION
Stackify is still there in packages and config settings, and this will still use stackify for APM.  Would be good to remove those eventually, but for now this should stop the logging.