### PR TITLE
Replace SparkPost library with System.Net.Mail

### DIFF
--- a/Purchasing.Jobs.NotificationsCommon/Purchasing.Jobs.NotificationsCommon.csproj
+++ b/Purchasing.Jobs.NotificationsCommon/Purchasing.Jobs.NotificationsCommon.csproj
@@ -22,7 +22,6 @@
 	<ItemGroup>
 		<PackageReference Include="Sendgrid" Version="9.27.0"/>
 		<PackageReference Include="Flurl.Http" Version="3.2.2"/>
-		<PackageReference Include="SparkPost.DotNetCore" Version="1.0.0"/>
 	</ItemGroup>
 	<ItemGroup>
 		<Content Include="appsettings.json"/>


### PR DESCRIPTION
I decided to just hardcode `smtp.sparkpostmail.com`, since that is what the api library effectively did. I figure we can move that and username credentials to appsettings if/when the need arises.