### PR TITLE
Ensure empty inputs are posted as empty strings

### DIFF
--- a/Purchasing.Mvc/Startup.cs
+++ b/Purchasing.Mvc/Startup.cs
@@ -62,6 +62,7 @@ namespace Purchasing.Mvc
                 options.ModelBinderProviders.Insert(
                     options.ModelBinderProviders.IndexOf(options.ModelBinderProviders.OfType<ComplexObjectModelBinderProvider>().First()),
                     new EntityModelBinderProvider());
+                options.ModelMetadataDetailsProviders.Add(new EmptyStringMetadataProvider());
             })
             .AddNewtonsoftJson(options =>
             {

--- a/UCDArch/Web/ModelBinder/EmptyStringMetadataProvider.cs
+++ b/UCDArch/Web/ModelBinder/EmptyStringMetadataProvider.cs
@@ -1,0 +1,17 @@
+using System;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+
+namespace UCDArch.Web.ModelBinder
+{
+    public class EmptyStringMetadataProvider : IMetadataDetailsProvider, IDisplayMetadataProvider
+    {
+        public void CreateDisplayMetadata(DisplayMetadataProviderContext context)
+        {
+            if (context.Key.ModelType == typeof(string) &&
+               (context.Key.MetadataKind == ModelMetadataKind.Property || context.Key.MetadataKind == ModelMetadataKind.Parameter))
+            {
+                context.DisplayMetadata.ConvertEmptyStringToNull = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This changes the default behavior to be more like asp.net 4.x. Right now the problem was only identified for an action string parameter, so maybe applying it to all model properties is overkill?