### PR TITLE
Fix unformatted unauthorized messages

### DIFF
--- a/Purchasing.Mvc/App_GlobalResources/Resources.resx
+++ b/Purchasing.Mvc/App_GlobalResources/Resources.resx
@@ -211,7 +211,7 @@
     <value>No results found</value>
   </data>
   <data name="Authorization_PermissionDenied" xml:space="preserve">
-    <value>You do not have the permissions required access this order</value>
+    <value>You do not have the permissions required to access this order</value>
   </data>
   <data name="NoAccess_Org" xml:space="preserve">
     <value>You do not have access to the requested Organization</value>

--- a/Purchasing.Mvc/Attributes/AuthorizeApplicationAccessAttribute.cs
+++ b/Purchasing.Mvc/Attributes/AuthorizeApplicationAccessAttribute.cs
@@ -4,6 +4,7 @@ using Purchasing.Mvc.App_GlobalResources;
 using Purchasing.Mvc.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Purchasing.Mvc.Helpers;
 
 namespace Purchasing.Mvc.Attributes
 {
@@ -18,7 +19,7 @@ namespace Purchasing.Mvc.Attributes
 
             if (!roles.Any())
             {
-                filterContext.Result = new UnauthorizedObjectResult(Resources.NoAccess_Application);
+                filterContext.Result = ViewHelper.NotAuthorized(Resources.NoAccess_Application);
             }
         }
     }

--- a/Purchasing.Mvc/Attributes/AuthorizeOrderAccessAttribute.cs
+++ b/Purchasing.Mvc/Attributes/AuthorizeOrderAccessAttribute.cs
@@ -6,6 +6,7 @@ using UCDArch.Core.PersistanceSupport;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using UCDArch.Core;
+using Purchasing.Mvc.Helpers;
 
 namespace Purchasing.Mvc.Attributes
 {
@@ -41,7 +42,7 @@ namespace Purchasing.Mvc.Attributes
 
             if (!_accessLevel.HasFlag(accessLevel))
             {
-                filterContext.Result = new UnauthorizedObjectResult(Resources.Authorization_PermissionDenied);
+                filterContext.Result = ViewHelper.NotAuthorized(Resources.Authorization_PermissionDenied);
             }
         }
     }

--- a/Purchasing.Mvc/Attributes/AuthorizeRequesterInOrderWorkgroupAttribute.cs
+++ b/Purchasing.Mvc/Attributes/AuthorizeRequesterInOrderWorkgroupAttribute.cs
@@ -7,6 +7,7 @@ using CommonServiceLocator;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using UCDArch.Core;
+using Purchasing.Mvc.Helpers;
 
 namespace Purchasing.Mvc.Attributes
 {
@@ -41,7 +42,7 @@ namespace Purchasing.Mvc.Attributes
 
             if (!hasRequestorPermission)
             {
-                filterContext.Result = new UnauthorizedObjectResult("You do not have access to copy this order");
+                filterContext.Result = ViewHelper.NotAuthorized("You do not have access to copy this order");
             }
         }
     }

--- a/Purchasing.Mvc/Attributes/AuthorizeWorkgroupAccessAttribute.cs
+++ b/Purchasing.Mvc/Attributes/AuthorizeWorkgroupAccessAttribute.cs
@@ -6,6 +6,7 @@ using UCDArch.Core.PersistanceSupport;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using UCDArch.Core;
+using Purchasing.Mvc.Helpers;
 
 namespace Purchasing.Mvc.Attributes
 {
@@ -53,7 +54,7 @@ namespace Purchasing.Mvc.Attributes
                 {
                     message = "You do not have access to edit this workgroup";
                 }
-                filterContext.Result = new UnauthorizedObjectResult(message);
+                filterContext.Result = ViewHelper.NotAuthorized(message);
             }
         }
     }

--- a/Purchasing.Mvc/Attributes/AuthorizeWorkgroupRoleAttribute.cs
+++ b/Purchasing.Mvc/Attributes/AuthorizeWorkgroupRoleAttribute.cs
@@ -3,6 +3,7 @@ using Purchasing.Mvc.App_GlobalResources;
 using Purchasing.Mvc.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Purchasing.Mvc.Helpers;
 
 namespace Purchasing.Mvc.Attributes
 {
@@ -21,7 +22,7 @@ namespace Purchasing.Mvc.Attributes
 
             if (!roles.Contains(_role))
             {
-                filterContext.Result = new UnauthorizedObjectResult(Resources.NoAccess);
+                filterContext.Result = ViewHelper.NotAuthorized(Resources.NoAccess);
             }
         }
     }

--- a/Purchasing.Mvc/Controllers/OrderController.cs
+++ b/Purchasing.Mvc/Controllers/OrderController.cs
@@ -24,6 +24,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Purchasing.Mvc.Helpers;
 
 namespace Purchasing.Mvc.Controllers
 {
@@ -594,7 +595,7 @@ namespace Purchasing.Mvc.Controllers
 
             if (!requiredAccessLevel.HasFlag(roleAndAccessLevel.OrderAccessLevel))
             {
-                return new UnauthorizedObjectResult(Resources.Authorization_PermissionDenied);
+                return ViewHelper.NotAuthorized(Resources.Authorization_PermissionDenied);
             }
             
             model.Vendor = _repositoryFactory.OrderRepository.Queryable.Where(x=>x.Id == id).Select(x=>x.Vendor).Single();

--- a/Purchasing.Mvc/Controllers/OrganizationController.cs
+++ b/Purchasing.Mvc/Controllers/OrganizationController.cs
@@ -7,6 +7,7 @@ using Purchasing.Core.Domain;
 using Purchasing.Mvc.Services;
 using UCDArch.Core.PersistanceSupport;
 using UCDArch.Core.Utils;
+using Purchasing.Mvc.Helpers;
 
 namespace Purchasing.Mvc.Controllers
 {
@@ -52,7 +53,7 @@ namespace Purchasing.Mvc.Controllers
             var message = string.Empty;
             if (!_securityService.HasWorkgroupOrOrganizationAccess(null, org, out message))
             {
-                return new UnauthorizedObjectResult(message);
+                return ViewHelper.NotAuthorized(message);
             }
 
             //var adminOrg = _queryRepositoryFactory.AdminOrgRepository.Queryable.Where(a => a.AccessUserId == CurrentUser.Identity.Name && a.IsActive && a.OrgId == id).Select(a => a.OrgId).FirstOrDefault();

--- a/Purchasing.Mvc/Helpers/ViewHelper.cs
+++ b/Purchasing.Mvc/Helpers/ViewHelper.cs
@@ -1,0 +1,30 @@
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using UCDArch.Core;
+
+namespace Purchasing.Mvc.Helpers
+{
+    public static class ViewHelper
+    {
+        public static ViewResult NotAuthorized(string errorMessage = null)
+        {
+            var result = new ViewResult
+            {
+                ViewName = "/Views/Error/NotAuthorized.cshtml",
+            };
+
+            if (!string.IsNullOrEmpty(errorMessage))
+            {
+                var httpContext = SmartServiceLocator<IHttpContextAccessor>.GetService().HttpContext;
+                var tempDataFactory = SmartServiceLocator<ITempDataDictionaryFactory>.GetService();
+                var tempData = tempDataFactory.GetTempData(httpContext);
+                tempData["ErrorMessage"] = errorMessage;
+            }
+
+            return result;
+        }
+    }
+}

--- a/Purchasing.Mvc/Views/Error/NotAuthorized.cshtml
+++ b/Purchasing.Mvc/Views/Error/NotAuthorized.cshtml
@@ -1,6 +1,9 @@
 ﻿@{
-    ViewBag.Title = "Not Authorized";
+  ViewBag.Title = "Not Authorized";
 }
 
-<h2>You are not authorized to view that.</h2>
-
+@* The default error message is not necessary if the error message banner is displayed. *@
+@if (!TempData.ContainsKey("ErrorMessage"))
+{
+  <h2>You are not authorized to view that.</h2>
+}


### PR DESCRIPTION
`UseStatusCodePages` doesn't seem to catch 401's from action/auth filters. I tried doing a redirect from the filters, but the error message in `TempData` wouldn't persist. So hopefully it's fine returning the view directly. I don't think this will impact any ajax calls. At least I can't imagine a situation where a user is authorized to view a page but not an ajax call that page makes.

A quick test is accessing `/order/rerouteaccountManager/1?approvalId=1` as user xxxx.