### PR TITLE
Log Less

### DIFF
--- a/Purchasing.Mvc/Logging/LogConfig.cs
+++ b/Purchasing.Mvc/Logging/LogConfig.cs
@@ -6,6 +6,7 @@ using Serilog.Sinks.Elasticsearch;
 using Serilog.Exceptions;
 using Microsoft.Extensions.Configuration;
 using Elastic.Apm.SerilogEnricher;
+using Serilog.Events;
 
 namespace Purchasing.Mvc.Logging
 {
@@ -24,6 +25,12 @@ namespace Purchasing.Mvc.Logging
             if (_loggingSetup) return; //only setup logging once
 
             Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+                // .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning) // uncomment this to hide EF core general info logs
+                .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
+                .MinimumLevel.Override("Elastic.Apm", LogEventLevel.Warning)
+                .MinimumLevel.Override("System", LogEventLevel.Warning)
                 .WriteTo.Console()
                 .WriteToElasticSearchCustom(configuration)
                 .Enrich.WithClientIp()

--- a/Purchasing.Mvc/Properties/launchSettings.json
+++ b/Purchasing.Mvc/Properties/launchSettings.json
@@ -21,7 +21,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+      "applicationUrl": "https://localhost:44396;http://localhost:44395"
     }
   }
 }


### PR DESCRIPTION
Reduces AspNetCore log entries to one per page access, and none for static assets. Prior to this PR, it was creating three log entries for every static asset and more for other resources.