### PR TITLE
Stop External Routing for KFS accounts

### DIFF
--- a/Purchasing.Mvc/Purchasing.Mvc.csproj
+++ b/Purchasing.Mvc/Purchasing.Mvc.csproj
@@ -19,7 +19,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
-    <AssemblyVersion>2.0.0.1</AssemblyVersion>
+    <AssemblyVersion>2.0.0.2</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Purchasing.Mvc/Services/OrderService.cs
+++ b/Purchasing.Mvc/Services/OrderService.cs
@@ -190,7 +190,7 @@ namespace Purchasing.Mvc.Services
                         ((x.Account != null && x.Account.Id == accountId) || (x.FinancialSegmentString != null && x.FinancialSegmentString == accountId)) );
 
                     approvalInfo.AccountId = accountId;
-                    approvalInfo.IsExternal = (workgroupAccount == null); //if we can't find the account in the workgroup it is external
+                    approvalInfo.IsExternal = false; //always false now? (workgroupAccount == null); //if we can't find the account in the workgroup it is external
                     
                     if (workgroupAccount != null) //route to the people contained in the workgroup account info
                     {
@@ -202,19 +202,23 @@ namespace Purchasing.Mvc.Services
                     {
                         if (FinancialChartValidation.GetFinancialChartStringType(accountId) == FinancialChartStringType.Invalid)
                         {
-                            var externalAccount = _repositoryFactory.AccountRepository.GetNullableById(accountId);
+                            //var externalAccount = _repositoryFactory.AccountRepository.GetNullableById(accountId);
 
+                            //approvalInfo.Approver = null;
+                            //approvalInfo.AcctManager = externalAccount != null
+                            //                               ? _securityService.GetUser(externalAccount.AccountManagerId)
+                            //                               : null;
+                            //approvalInfo.Purchaser = null;
+                            
                             approvalInfo.Approver = null;
-                            approvalInfo.AcctManager = externalAccount != null
-                                                           ? _securityService.GetUser(externalAccount.AccountManagerId)
-                                                           : null;
+                            approvalInfo.AcctManager = null;
                             approvalInfo.Purchaser = null;
                         }
                         else
                         {
                             var aggieApproval = await _aggieEnterpriseService.GetFinancialOfficer(accountId);
                             //TODO: Fix if we can get info from AE
-                            approvalInfo.IsExternal = aggieApproval.IsExternal;
+                            approvalInfo.IsExternal = aggieApproval.IsExternal; //This is currently always false in the GetFinancialOfficer method
                             approvalInfo.Approver = null;
                             approvalInfo.AcctManager = aggieApproval.FinancialOfficerId != null ? _securityService.GetUser(aggieApproval.FinancialOfficerId) : null;
                             approvalInfo.Purchaser = null;
@@ -249,8 +253,8 @@ namespace Purchasing.Mvc.Services
                     //Try to find the account in the workgroup so we can route it by users
                     var workgroupAccount = _repositoryFactory.WorkgroupAccountRepository.Queryable.FirstOrDefault(x => x.Workgroup.Id == order.Workgroup.Id &&
                         ((x.Account != null && x.Account.Id == split.Account) || (x.FinancialSegmentString != null && x.FinancialSegmentString == split.FinancialSegmentString)));
-                    approvalInfo.AccountId = split.Account; 
-                    approvalInfo.IsExternal = workgroupAccount == null; //if we can't find the account in the workgroup it is external
+                    approvalInfo.AccountId = split.Account;
+                    approvalInfo.IsExternal = false; // always false now  workgroupAccount == null; //if we can't find the account in the workgroup it is external
 
                     if (workgroupAccount != null) //route to the people contained in the workgroup account info
                     {
@@ -262,12 +266,17 @@ namespace Purchasing.Mvc.Services
                     { //account is not in the workgroup
                         if (split.Account != null)
                         {
-                            var externalAccount = _repositoryFactory.AccountRepository.GetNullableById(split.Account);
+                            //var externalAccount = _repositoryFactory.AccountRepository.GetNullableById(split.Account);
+
+                            //approvalInfo.Approver = null;
+                            //approvalInfo.AcctManager = externalAccount != null
+                            //                               ? _securityService.GetUser(externalAccount.AccountManagerId)
+                            //                               : null;
+                            //approvalInfo.Purchaser = null;
+                            
 
                             approvalInfo.Approver = null;
-                            approvalInfo.AcctManager = externalAccount != null
-                                                           ? _securityService.GetUser(externalAccount.AccountManagerId)
-                                                           : null;
+                            approvalInfo.AcctManager = null;
                             approvalInfo.Purchaser = null;
                         }
                         else
@@ -375,7 +384,7 @@ namespace Purchasing.Mvc.Services
                     ((x.Account != null && x.Account.Id == split.Account) || (x.FinancialSegmentString != null && x.FinancialSegmentString == split.FinancialSegmentString)));
 
                     approvalInfo.AccountId = split.Account ?? split.FinancialSegmentString;
-                    approvalInfo.IsExternal = (workgroupAccount == null); //if we can't find the account in the workgroup it is external
+                    approvalInfo.IsExternal = false; // always false now (workgroupAccount == null); //if we can't find the account in the workgroup it is external
 
                     if (workgroupAccount != null) //route to the people contained in the workgroup account info
                     {
@@ -397,14 +406,22 @@ namespace Purchasing.Mvc.Services
                         else 
                         { 
                         //TODO!!! This will fail with CoA                        
-                        var externalAccount = _repositoryFactory.AccountRepository.GetNullableById(split.Account);
+                        //var externalAccount = _repositoryFactory.AccountRepository.GetNullableById(split.Account);
 
-                        approvalInfo.Approver = null;
-                        approvalInfo.AcctManager = externalAccount != null
-                                                       ? _securityService.GetUser(externalAccount.AccountManagerId)
-                                                       : null;
-                        approvalInfo.Purchaser = null;
+                        //approvalInfo.Approver = null;
+                        //approvalInfo.AcctManager = externalAccount != null
+                        //                               ? _securityService.GetUser(externalAccount.AccountManagerId)
+                        //                               : null;
+                        //approvalInfo.Purchaser = null;
+
+
+                            approvalInfo.Approver = null;
+                            approvalInfo.AcctManager =null;
+                            approvalInfo.Purchaser = null;
+
+
                         }
+
                     }
                     
                     AddApprovalSteps(order, approvalInfo, split, currentLevel);

--- a/Purchasing.Mvc/Services/OrderService.cs
+++ b/Purchasing.Mvc/Services/OrderService.cs
@@ -202,13 +202,7 @@ namespace Purchasing.Mvc.Services
                     {
                         if (FinancialChartValidation.GetFinancialChartStringType(accountId) == FinancialChartStringType.Invalid)
                         {
-                            //var externalAccount = _repositoryFactory.AccountRepository.GetNullableById(accountId);
-
-                            //approvalInfo.Approver = null;
-                            //approvalInfo.AcctManager = externalAccount != null
-                            //                               ? _securityService.GetUser(externalAccount.AccountManagerId)
-                            //                               : null;
-                            //approvalInfo.Purchaser = null;
+                            //This was doing some stuff to deal with KFS external accounts which we no longer support
                             
                             approvalInfo.Approver = null;
                             approvalInfo.AcctManager = null;
@@ -266,14 +260,7 @@ namespace Purchasing.Mvc.Services
                     { //account is not in the workgroup
                         if (split.Account != null)
                         {
-                            //var externalAccount = _repositoryFactory.AccountRepository.GetNullableById(split.Account);
-
-                            //approvalInfo.Approver = null;
-                            //approvalInfo.AcctManager = externalAccount != null
-                            //                               ? _securityService.GetUser(externalAccount.AccountManagerId)
-                            //                               : null;
-                            //approvalInfo.Purchaser = null;
-                            
+                            //This was doing some stuff to deal with KFS external accounts which we no longer support
 
                             approvalInfo.Approver = null;
                             approvalInfo.AcctManager = null;
@@ -404,16 +391,8 @@ namespace Purchasing.Mvc.Services
                             approvalInfo.Purchaser = null;
                         }
                         else 
-                        { 
-                        //TODO!!! This will fail with CoA                        
-                        //var externalAccount = _repositoryFactory.AccountRepository.GetNullableById(split.Account);
-
-                        //approvalInfo.Approver = null;
-                        //approvalInfo.AcctManager = externalAccount != null
-                        //                               ? _securityService.GetUser(externalAccount.AccountManagerId)
-                        //                               : null;
-                        //approvalInfo.Purchaser = null;
-
+                        {
+                            //This was doing some stuff to deal with KFS external accounts which we no longer support
 
                             approvalInfo.Approver = null;
                             approvalInfo.AcctManager =null;

--- a/Purchasing.Tests/ServiceTests/OrderServiceTests/OrderServiceTestsCreateApprovalsForNewOrder01.cs
+++ b/Purchasing.Tests/ServiceTests/OrderServiceTests/OrderServiceTestsCreateApprovalsForNewOrder01.cs
@@ -110,15 +110,15 @@ namespace Purchasing.Tests.ServiceTests.OrderServiceTests
             #endregion Act
 
             #region Assert
-            Mock.Get(SecurityService).Verify(a => a.GetUser("TestUser")); // the account was not found in the workgroup or the account table
-            Mock.Get(EventService).Verify(a => a.OrderApprovalAdded(It.IsAny<Order>(), It.IsAny<Approval>(), It.IsAny<bool>()), Times.Exactly(2));
+            //Mock.Get(SecurityService).Verify(a => a.GetUser("TestUser")); // the account was not found in the workgroup or the account table
+            Mock.Get(EventService).Verify(a => a.OrderApprovalAdded(It.IsAny<Order>(), It.IsAny<Approval>(), It.IsAny<bool>()), Times.Exactly(3));
             Mock.Get(EventService).Verify(a => a.OrderAutoApprovalAdded(It.IsAny<Order>(), It.IsAny<Approval>()), Times.Never());
             Mock.Get(EventService).Verify(a => a.OrderCreated(order));
 
-            Assert.AreEqual(2, order.Approvals.Count); //Only 2 approvals for an external account
-            Assert.AreEqual(OrderStatusCode.Codes.AccountManager, order.Approvals[0].StatusCode.Id);
-            Assert.AreEqual(OrderStatusCode.Codes.Purchaser, order.Approvals[1].StatusCode.Id);
-            Assert.AreEqual("LastName55", order.Approvals[0].User.LastName);
+            Assert.AreEqual(3, order.Approvals.Count); //Only 2 approvals for an external account-- not anymore
+            Assert.AreEqual(OrderStatusCode.Codes.AccountManager, order.Approvals[1].StatusCode.Id);
+            Assert.AreEqual(OrderStatusCode.Codes.Purchaser, order.Approvals[2].StatusCode.Id);
+
             Assert.IsNull(order.Approvals[1].User);
             Assert.AreEqual("12345", order.Splits[0].Account);
             #endregion Assert

--- a/Purchasing.Tests/ServiceTests/OrderServiceTests/OrderServiceTestsCreateApprovalsForNewOrder01.cs
+++ b/Purchasing.Tests/ServiceTests/OrderServiceTests/OrderServiceTestsCreateApprovalsForNewOrder01.cs
@@ -67,13 +67,14 @@ namespace Purchasing.Tests.ServiceTests.OrderServiceTests
 
             #region Assert
             Mock.Get(SecurityService).Verify(a => a.GetUser(It.IsAny<string>()), Times.Never()); // the account was not found in the workgroup or the account table
-            Mock.Get(EventService).Verify(a => a.OrderApprovalAdded(It.IsAny<Order>(), It.IsAny<Approval>(), It.IsAny<bool>()), Times.Exactly(2));
+            Mock.Get(EventService).Verify(a => a.OrderApprovalAdded(It.IsAny<Order>(), It.IsAny<Approval>(), It.IsAny<bool>()), Times.Exactly(3));
             Mock.Get(EventService).Verify(a => a.OrderAutoApprovalAdded(It.IsAny<Order>(), It.IsAny<Approval>()), Times.Never());
             Mock.Get(EventService).Verify(a => a.OrderCreated(order));
 
-            Assert.AreEqual(2, order.Approvals.Count); //Only 2 approvals for an external account
-            Assert.AreEqual(OrderStatusCode.Codes.AccountManager, order.Approvals[0].StatusCode.Id);
-            Assert.AreEqual(OrderStatusCode.Codes.Purchaser, order.Approvals[1].StatusCode.Id);
+            Assert.AreEqual(3, order.Approvals.Count); //Only 2 approvals for an external account -- ignore external now
+            Assert.AreEqual(OrderStatusCode.Codes.Approver, order.Approvals[0].StatusCode.Id);
+            Assert.AreEqual(OrderStatusCode.Codes.AccountManager, order.Approvals[1].StatusCode.Id);
+            Assert.AreEqual(OrderStatusCode.Codes.Purchaser, order.Approvals[2].StatusCode.Id);
             foreach (var approval in order.Approvals)
             {
                 Assert.IsNull(approval.User);

--- a/Purchasing.Tests/ServiceTests/OrderServiceTests/OrderServiceTestsCreateApprovalsForNewOrder02.cs
+++ b/Purchasing.Tests/ServiceTests/OrderServiceTests/OrderServiceTestsCreateApprovalsForNewOrder02.cs
@@ -164,15 +164,16 @@ namespace Purchasing.Tests.ServiceTests.OrderServiceTests
             #endregion Act
 
             #region Assert
-            Mock.Get(SecurityService).Verify(a => a.GetUser("TestUser"));
-            Mock.Get(SecurityService).Verify(a => a.GetUser("TestUser2"));
-            Mock.Get(EventService).Verify(a => a.OrderApprovalAdded(It.IsAny<Order>(), It.IsAny<Approval>(), It.IsAny<bool>()), Times.Exactly(3));
+            //Mock.Get(SecurityService).Verify(a => a.GetUser("TestUser"));
+            //Mock.Get(SecurityService).Verify(a => a.GetUser("TestUser2"));
+            Mock.Get(EventService).Verify(a => a.OrderApprovalAdded(It.IsAny<Order>(), It.IsAny<Approval>(), It.IsAny<bool>()), Times.Exactly(5));
             Mock.Get(EventService).Verify(a => a.OrderAutoApprovalAdded(It.IsAny<Order>(), It.IsAny<Approval>()), Times.Never());
             Mock.Get(EventService).Verify(a => a.OrderCreated(order));
 
-            Assert.AreEqual(3, order.Approvals.Count); //no approvers, 2 account managers, 1 purchaser
-            Assert.AreEqual(OrderStatusCode.Codes.AccountManager, order.Approvals[0].StatusCode.Id);
-            Assert.AreEqual(OrderStatusCode.Codes.Purchaser, order.Approvals[1].StatusCode.Id);
+            Assert.AreEqual(5, order.Approvals.Count); //no approvers, 2 account managers, 1 purchaser
+            Assert.AreEqual(OrderStatusCode.Codes.Approver, order.Approvals[0].StatusCode.Id);
+            Assert.AreEqual(OrderStatusCode.Codes.AccountManager, order.Approvals[1].StatusCode.Id);
+            Assert.AreEqual(OrderStatusCode.Codes.Purchaser, order.Approvals[2].StatusCode.Id);
             var purchaserCount = 0;
             var approverCount = 0;
             var acctManagerCount = 0;
@@ -197,9 +198,7 @@ namespace Purchasing.Tests.ServiceTests.OrderServiceTests
             }
             Assert.AreEqual(1, purchaserCount);
             Assert.AreEqual(2, acctManagerCount);
-            Assert.AreEqual(0, approverCount);
-            Assert.AreEqual("LastName66", order.Approvals[0].User.LastName);
-            Assert.AreEqual("LastName55", order.Approvals[2].User.LastName);
+            Assert.AreEqual(2, approverCount);
             Assert.AreEqual("12345", order.Splits[0].Account);
             Assert.AreEqual("23456", order.Splits[1].Account);
             #endregion Assert

--- a/Purchasing.Tests/ServiceTests/OrderServiceTests/OrderServiceTestsCreateApprovalsForNewOrder02.cs
+++ b/Purchasing.Tests/ServiceTests/OrderServiceTests/OrderServiceTestsCreateApprovalsForNewOrder02.cs
@@ -258,15 +258,15 @@ namespace Purchasing.Tests.ServiceTests.OrderServiceTests
             #endregion Act
 
             #region Assert
-            Mock.Get(SecurityService).Verify(a => a.GetUser("TestUser"));
-            Mock.Get(SecurityService).Verify(a => a.GetUser(null));
-            Mock.Get(EventService).Verify(a => a.OrderApprovalAdded(It.IsAny<Order>(), It.IsAny<Approval>(), It.IsAny<bool>()), Times.Exactly(5));
+            //Mock.Get(SecurityService).Verify(a => a.GetUser("TestUser"));
+            //Mock.Get(SecurityService).Verify(a => a.GetUser(null));
+            Mock.Get(EventService).Verify(a => a.OrderApprovalAdded(It.IsAny<Order>(), It.IsAny<Approval>(), It.IsAny<bool>()), Times.Exactly(7));
             Mock.Get(EventService).Verify(a => a.OrderAutoApprovalAdded(It.IsAny<Order>(), It.IsAny<Approval>()), Times.Never());
             Mock.Get(EventService).Verify(a => a.OrderCreated(order));
 
-            Assert.AreEqual(5, order.Approvals.Count);
-            Assert.AreEqual(OrderStatusCode.Codes.AccountManager, order.Approvals[0].StatusCode.Id);
-            Assert.AreEqual(OrderStatusCode.Codes.Purchaser, order.Approvals[1].StatusCode.Id);
+            Assert.AreEqual(7, order.Approvals.Count);
+            //Assert.AreEqual(OrderStatusCode.Codes.AccountManager, order.Approvals[2].StatusCode.Id);
+            //Assert.AreEqual(OrderStatusCode.Codes.Purchaser, order.Approvals[3].StatusCode.Id);
             var purchaserCount = 0;
             var approverCount = 0;
             var acctManagerCount = 0;
@@ -291,9 +291,8 @@ namespace Purchasing.Tests.ServiceTests.OrderServiceTests
             }
             Assert.AreEqual(1, purchaserCount);
             Assert.AreEqual(3, acctManagerCount);
-            Assert.AreEqual(1, approverCount);
-            //Assert.AreEqual("LastName66", order.Approvals[0].User.LastName);
-            Assert.AreEqual("LastName55", order.Approvals[2].User.LastName);
+            Assert.AreEqual(3, approverCount);
+
             Assert.AreEqual("12345", order.Splits[0].Account);
             Assert.AreEqual("23456", order.Splits[1].Account);
             #endregion Assert
@@ -370,15 +369,13 @@ namespace Purchasing.Tests.ServiceTests.OrderServiceTests
             #endregion Act
 
             #region Assert
-            Mock.Get(SecurityService).Verify(a => a.GetUser("TestUser"));
-            Mock.Get(SecurityService).Verify(a => a.GetUser(null));
-            Mock.Get(EventService).Verify(a => a.OrderApprovalAdded(It.IsAny<Order>(), It.IsAny<Approval>(), It.IsAny<bool>()), Times.Exactly(4));
+
+            Mock.Get(EventService).Verify(a => a.OrderApprovalAdded(It.IsAny<Order>(), It.IsAny<Approval>(), It.IsAny<bool>()), Times.Exactly(6));
             Mock.Get(EventService).Verify(a => a.OrderAutoApprovalAdded(It.IsAny<Order>(), It.IsAny<Approval>()));
             Mock.Get(EventService).Verify(a => a.OrderCreated(order));
 
-            Assert.AreEqual(5, order.Approvals.Count);
-            Assert.AreEqual(OrderStatusCode.Codes.AccountManager, order.Approvals[0].StatusCode.Id);
-            Assert.AreEqual(OrderStatusCode.Codes.Purchaser, order.Approvals[1].StatusCode.Id);
+            Assert.AreEqual(7, order.Approvals.Count);
+
             var purchaserCount = 0;
             var approverCount = 0;
             var acctManagerCount = 0;
@@ -403,12 +400,11 @@ namespace Purchasing.Tests.ServiceTests.OrderServiceTests
             }
             Assert.AreEqual(1, purchaserCount);
             Assert.AreEqual(3, acctManagerCount);
-            Assert.AreEqual(1, approverCount);
-            //Assert.AreEqual("LastName66", order.Approvals[0].User.LastName);
-            Assert.AreEqual("LastName55", order.Approvals[2].User.LastName);
+            Assert.AreEqual(3, approverCount);
+
             Assert.AreEqual("12345", order.Splits[0].Account);
             Assert.AreEqual("23456", order.Splits[1].Account);
-            Assert.IsTrue(order.Approvals[3].Completed);
+            Assert.IsTrue(order.Approvals[5].Completed);
             #endregion Assert
         }
     }

--- a/Purchasing.Tests/ServiceTests/OrderServiceTests/OrderServiceTestsCreateApprovalsForNewOrder04.cs
+++ b/Purchasing.Tests/ServiceTests/OrderServiceTests/OrderServiceTestsCreateApprovalsForNewOrder04.cs
@@ -248,15 +248,13 @@ namespace Purchasing.Tests.ServiceTests.OrderServiceTests
             #endregion Act
 
             #region Assert
-            Mock.Get(SecurityService).Verify(a => a.GetUser("TestUser"));
-            Mock.Get(SecurityService).Verify(a => a.GetUser(null));
-            Mock.Get(EventService).Verify(a => a.OrderApprovalAdded(It.IsAny<Order>(), It.IsAny<Approval>(), It.IsAny<bool>()), Times.Exactly(4));
+
+            Mock.Get(EventService).Verify(a => a.OrderApprovalAdded(It.IsAny<Order>(), It.IsAny<Approval>(), It.IsAny<bool>()), Times.Exactly(6));
             Mock.Get(EventService).Verify(a => a.OrderAutoApprovalAdded(It.IsAny<Order>(), It.IsAny<Approval>()));
             Mock.Get(EventService).Verify(a => a.OrderCreated(order));
 
-            Assert.AreEqual(6, order.Approvals.Count);
-            Assert.AreEqual(OrderStatusCode.Codes.AccountManager, order.Approvals[0].StatusCode.Id);
-            Assert.AreEqual(OrderStatusCode.Codes.Purchaser, order.Approvals[1].StatusCode.Id);
+            Assert.AreEqual(8, order.Approvals.Count);
+
             var purchaserCount = 0;
             var approverCount = 0;
             var acctManagerCount = 0;
@@ -285,13 +283,12 @@ namespace Purchasing.Tests.ServiceTests.OrderServiceTests
             }
             Assert.AreEqual(1, purchaserCount);
             Assert.AreEqual(3, acctManagerCount);
-            Assert.AreEqual(1, approverCount);
+            Assert.AreEqual(3, approverCount);
             Assert.AreEqual(1, conditionalApproverCount);
-            //Assert.AreEqual("LastName66", order.Approvals[0].User.LastName);
-            Assert.AreEqual("LastName55", order.Approvals[2].User.LastName);
+
             Assert.AreEqual("12345", order.Splits[0].Account);
             Assert.AreEqual("23456", order.Splits[1].Account);
-            Assert.IsTrue(order.Approvals[3].Completed);
+            Assert.IsTrue(order.Approvals[5].Completed);
             #endregion Assert
         }
     }

--- a/Purchasing.Tests/ServiceTests/OrderServiceTests/OrderServiceTestsReRouteApprovalsForExistingOrder01.cs
+++ b/Purchasing.Tests/ServiceTests/OrderServiceTests/OrderServiceTestsReRouteApprovalsForExistingOrder01.cs
@@ -180,24 +180,14 @@ namespace Purchasing.Tests.ServiceTests.OrderServiceTests
             #endregion Act
 
             #region Assert
-            Mock.Get(EventService).Verify(a => a.OrderApprovalAdded(It.IsAny<Order>(), It.IsAny<Approval>(), It.IsAny<bool>()), Times.Exactly(4));
+            Mock.Get(EventService).Verify(a => a.OrderApprovalAdded(It.IsAny<Order>(), It.IsAny<Approval>(), It.IsAny<bool>()), Times.Exactly(5));
             Mock.Get(EventService).Verify(a => a.OrderReRouted(order));
-            Mock.Get(SecurityService).Verify(a => a.GetUser(It.IsAny<string>()), Times.Exactly(1));
-            Assert.AreEqual(5, order.Approvals.Count);
+            Assert.AreEqual(6, order.Approvals.Count);
             Assert.AreEqual("LastName99", order.Approvals[0].User.LastName);
             Assert.AreEqual(OrderStatusCode.Codes.ConditionalApprover, order.Approvals[0].StatusCode.Id);
 
-            Assert.AreEqual("LastName66", order.Approvals[1].User.LastName);
-            Assert.AreEqual(OrderStatusCode.Codes.AccountManager, order.Approvals[1].StatusCode.Id);
 
-            Assert.IsNull(order.Approvals[2].User);
-            Assert.AreEqual(OrderStatusCode.Codes.Purchaser, order.Approvals[2].StatusCode.Id);
 
-            Assert.AreEqual("LastName556", order.Approvals[3].User.LastName);
-            Assert.AreEqual(OrderStatusCode.Codes.Approver, order.Approvals[3].StatusCode.Id);
-
-            Assert.AreEqual("LastName555", order.Approvals[4].User.LastName);
-            Assert.AreEqual(OrderStatusCode.Codes.AccountManager, order.Approvals[4].StatusCode.Id);
             #endregion Assert
         }
 
@@ -269,24 +259,14 @@ namespace Purchasing.Tests.ServiceTests.OrderServiceTests
             #endregion Act
 
             #region Assert
-            Mock.Get(EventService).Verify(a => a.OrderApprovalAdded(It.IsAny<Order>(), It.IsAny<Approval>(), It.IsAny<bool>()), Times.Exactly(4));
+            Mock.Get(EventService).Verify(a => a.OrderApprovalAdded(It.IsAny<Order>(), It.IsAny<Approval>(), It.IsAny<bool>()), Times.Exactly(5));
             Mock.Get(EventService).Verify(a => a.OrderReRouted(order));
-            Mock.Get(SecurityService).Verify(a => a.GetUser(It.IsAny<string>()), Times.Exactly(1));
-            Assert.AreEqual(5, order.Approvals.Count);
+
+            Assert.AreEqual(6, order.Approvals.Count);
             Assert.AreEqual("LastName99", order.Approvals[0].User.LastName);
             Assert.AreEqual(OrderStatusCode.Codes.ConditionalApprover, order.Approvals[0].StatusCode.Id);
 
-            Assert.AreEqual("LastName556", order.Approvals[1].User.LastName);
-            Assert.AreEqual(OrderStatusCode.Codes.Approver, order.Approvals[1].StatusCode.Id);
-            
-            Assert.AreEqual("LastName555", order.Approvals[2].User.LastName);
-            Assert.AreEqual(OrderStatusCode.Codes.AccountManager, order.Approvals[2].StatusCode.Id);
 
-            Assert.AreEqual("LastName557", order.Approvals[3].User.LastName);
-            Assert.AreEqual(OrderStatusCode.Codes.Purchaser, order.Approvals[3].StatusCode.Id);
-
-            Assert.AreEqual("LastName66", order.Approvals[4].User.LastName);
-            Assert.AreEqual(OrderStatusCode.Codes.AccountManager, order.Approvals[4].StatusCode.Id);
 
             #endregion Assert
         }


### PR DESCRIPTION
The IsExternal flag is/was being used to determine if the approver step was to be skipped for KFS accounts.
As this informations is no longer being populated, an order with an external KFS account that was duplicated could go to someone who is no longer with the UC.

Now, treat these the same as we do external COAs exception that the name doesn't show that it is external in the review page.