### PR TITLE
Jcs/auto populate po

### DIFF
--- a/Purchasing.Mvc/Controllers/OrderController.cs
+++ b/Purchasing.Mvc/Controllers/OrderController.cs
@@ -620,6 +620,8 @@ namespace Purchasing.Mvc.Controllers
             {
                 return ViewHelper.NotAuthorized(Resources.Authorization_PermissionDenied);
             }
+
+            await _orderService.TryPopulatePoNumberFromAggieEnterprise(model.Order);
             
             model.Vendor = _repositoryFactory.OrderRepository.Queryable.Where(x=>x.Id == id).Select(x=>x.Vendor).Single();
             if(model.Vendor != null && !string.IsNullOrWhiteSpace( model.Vendor.AeSupplierNumber ))

--- a/Purchasing.Mvc/Services/OrderService.cs
+++ b/Purchasing.Mvc/Services/OrderService.cs
@@ -652,25 +652,33 @@ namespace Purchasing.Mvc.Services
 
         public async Task<bool> TryPopulatePoNumberFromAggieEnterprise(Order order)
         {
-            if (order.StatusCode?.Id != OrderStatusCode.Codes.Complete ||
-                order.OrderType?.Id?.Trim() != OrderType.Types.AggieEnterprise ||
-                string.IsNullOrWhiteSpace(order.ReferenceNumber) ||
-                !string.IsNullOrWhiteSpace(order.PoNumber))
+            try
             {
+                if (order.StatusCode?.Id != OrderStatusCode.Codes.Complete ||
+                    order.OrderType?.Id?.Trim() != OrderType.Types.AggieEnterprise ||
+                    string.IsNullOrWhiteSpace(order.ReferenceNumber) ||
+                    !string.IsNullOrWhiteSpace(order.PoNumber))
+                {
+                    return false;
+                }
+
+                var status = await _aggieEnterpriseService.LookupOrderStatus(order.ReferenceNumber.Trim());
+                if (string.IsNullOrWhiteSpace(status?.PoNumber))
+                {
+                    return false;
+                }
+
+                order.PoNumber = status.PoNumber.Trim();
+                _eventService.OrderUpdated(order, $"PO # automatically populated from Aggie Enterprise: {order.PoNumber}");
+                _orderRepository.EnsurePersistent(order);
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                //swallow it.
                 return false;
             }
-
-            var status = await _aggieEnterpriseService.LookupOrderStatus(order.ReferenceNumber.Trim());
-            if (string.IsNullOrWhiteSpace(status?.PoNumber))
-            {
-                return false;
-            }
-
-            order.PoNumber = status.PoNumber.Trim();
-            _eventService.OrderUpdated(order, $"PO # automatically populated from Aggie Enterprise: {order.PoNumber}");
-            _orderRepository.EnsurePersistent(order);
-
-            return true;
         }
 
         /// <summary>

--- a/Purchasing.Mvc/Services/OrderService.cs
+++ b/Purchasing.Mvc/Services/OrderService.cs
@@ -71,6 +71,8 @@ namespace Purchasing.Mvc.Services
         /// <returns>String array of error messages, non-empty if completion didn't succeed</returns>
         Task<string[]> Complete(Order order, OrderType newOrderType, string kfsDocType = null);
 
+        Task<bool> TryPopulatePoNumberFromAggieEnterprise(Order order);
+
         /// <summary>
         /// Get the current user's list of orders.
         /// </summary>
@@ -646,6 +648,29 @@ namespace Purchasing.Mvc.Services
             _eventService.OrderCompleted(order);
 
             return new string[0]; //return no errors
+        }
+
+        public async Task<bool> TryPopulatePoNumberFromAggieEnterprise(Order order)
+        {
+            if (order.StatusCode?.Id != OrderStatusCode.Codes.Complete ||
+                order.OrderType?.Id?.Trim() != OrderType.Types.AggieEnterprise ||
+                string.IsNullOrWhiteSpace(order.ReferenceNumber) ||
+                !string.IsNullOrWhiteSpace(order.PoNumber))
+            {
+                return false;
+            }
+
+            var status = await _aggieEnterpriseService.LookupOrderStatus(order.ReferenceNumber.Trim());
+            if (string.IsNullOrWhiteSpace(status?.PoNumber))
+            {
+                return false;
+            }
+
+            order.PoNumber = status.PoNumber.Trim();
+            _eventService.OrderUpdated(order, $"PO # automatically populated from Aggie Enterprise: {order.PoNumber}");
+            _orderRepository.EnsurePersistent(order);
+
+            return true;
         }
 
         /// <summary>

--- a/Purchasing.Mvc/Views/Help/Index.cshtml
+++ b/Purchasing.Mvc/Views/Help/Index.cshtml
@@ -67,8 +67,8 @@
     </section>
     <section id="faq" class="container split">
         <header>
-            <a class="button" href="@faqUrl" target="_blank">
-                Knowledge Base
+            <a href="@faqUrl" target="_blank">
+                <img src='@Url.Content("~/Images/knowledgebase.png")' alt="knowledge base"/>
             </a>
         </header>
     

--- a/Purchasing.Mvc/Views/Help/Index.cshtml
+++ b/Purchasing.Mvc/Views/Help/Index.cshtml
@@ -22,12 +22,7 @@
     </header>
     
     <div class="contents">
-        
-        <p>Help make PrePurchasing better with your ideas</p>
-        <ul>
-            <li>See a suggestion you like?  Vote for it!</li>
-            <li>Make your own suggestions</li>
-        </ul>
+        <p>Share ideas and vote for improvements suggested by other users.</p>
     </div>
 
 </section>
@@ -39,9 +34,7 @@
         </header>
     
         <div class="contents">
-        
-            <p>Need some help?  Try submitting a ticket to our help desk.</p>
-
+            <p>Submit a help ticket for technical problems or unexpected behavior.</p>
         </div>
 
     </section>
@@ -54,14 +47,7 @@
         </header>
     
         <div class="contents">
-        
-            <p>Who should I contact?</p>
-            <ul>
-                <li>What Workgroups do you belong to?</li>
-                <li>Who are the Departmental Admins for those workgroups?</li>
-                <li>Have a technical questions instead? Try the other help button.</li>
-            </ul>
-
+            <p>Find your workgroups and the departmental admins who support them.</p>
         </div>
 
     </section>
@@ -73,9 +59,7 @@
         </header>
     
         <div class="contents">
-        
-            <p>Try our knowledge base.</p>
-
+            <p>Browse guides and answers to common PrePurchasing questions.</p>
         </div>
 
     </section>
@@ -86,7 +70,10 @@
     <style type="text/css">
         .container { display: inline-block;margin: .5em 0;padding: 1em;}
         .split {width: 47%;float: left;}
-        .container header { margin: auto;padding: 0;color: #014A81; }
-        .container ul { margin: 0 20px;}
+        #keeper::after { content: ""; display: block; clear: both; }
+        .split header, .split .contents { width: 350px; margin-left: auto; margin-right: auto; }
+        .container header { padding: 0;color: #014A81; }
+        .split .contents { box-sizing: border-box; margin-top: .75em; padding: 0 .25em; color: #3f4f5a; font-size: .95em; line-height: 1.4; text-align: center; }
+        .split .contents p { margin: 0; }
     </style>
 }

--- a/Purchasing.Mvc/Views/Home/Index.cshtml
+++ b/Purchasing.Mvc/Views/Home/Index.cshtml
@@ -185,7 +185,7 @@
 
                 </div>
 
-                <div id="announce">
+@*                 <div id="announce">
 
                     <h2>Aggie Enterprise Announcement!</h2>
 
@@ -197,7 +197,7 @@
                     </p>
 
                     <p><a href="https://computing.caes.ucdavis.edu/documentation/purchasing/Aggie-Enterprise-Updates" target="_blank">This FAQ has some updates and useful information.</a></p>
-                </div>
+                </div> *@
                 
                 
                 <div id="browsers">

--- a/Purchasing.Mvc/Views/Order/_ReviewSubmit.cshtml
+++ b/Purchasing.Mvc/Views/Order/_ReviewSubmit.cshtml
@@ -26,7 +26,7 @@
             if (Model.IsPurchaser)
             {
                 <div id="status-message">
-                    You may now complete orders in Aggie Enterprise!
+                    August 2026: Aggie Enterprise now supports editing orders uploaded from PrePurchasing. Complete this as Aggie Enterprise to use this feature.
                 </div>
             }
         }

--- a/Purchasing.Mvc/Views/Organization/Details.cshtml
+++ b/Purchasing.Mvc/Views/Organization/Details.cshtml
@@ -38,6 +38,19 @@
 			<div class="display-details">@Model.TypeName</div>
 		</li>
 		<li>
+			<div class="display-label">Parent Org</div>
+			<div class="display-details">
+                @if (Model.Parent != null)
+                {
+                    @Html.ActionLink($"{Model.Parent.Name} ({Model.Parent.Id})", "Details", "Organization", new { id = Model.Parent.Id }, new { })
+                }
+                else
+                {
+                    @:n/a
+                }
+			</div>
+		</li>
+		<li>
 			<div class="display-label">Is Active</div>
 			<div class="display-details">@Model.IsActive</div>
 		</li>

--- a/Purchasing.Tests/ServiceTests/OrderServiceTests/OrderServiceTestsMisc01.cs
+++ b/Purchasing.Tests/ServiceTests/OrderServiceTests/OrderServiceTestsMisc01.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Purchasing.Core.Domain;
+using Purchasing.Core.Models.AggieEnterprise;
 using Purchasing.Tests.Core;
 using UCDArch.Testing;
 using UCDArch.Testing.Extensions;
@@ -49,5 +50,84 @@ namespace Purchasing.Tests.ServiceTests.OrderServiceTests
             #endregion Assert		
         }
         #endregion ReRouteSingleApprovalForExistingOrder Tests
+
+        #region TryPopulatePoNumberFromAggieEnterprise Tests
+
+        [TestMethod]
+        public async System.Threading.Tasks.Task TestTryPopulatePoNumberFromAggieEnterprisePopulatesPoAndAddsHistory()
+        {
+            var order = CreateValidEntities.Order(1);
+            order.StatusCode.Id = OrderStatusCode.Codes.Complete;
+            order.OrderType = new OrderType(OrderType.Types.AggieEnterprise);
+            order.ReferenceNumber = " 184e9d20-f759-413e-8f42-06db62bf1e59 ";
+            order.PoNumber = " ";
+
+            Mock.Get(AggieEnterpriseService)
+                .Setup(a => a.LookupOrderStatus("184e9d20-f759-413e-8f42-06db62bf1e59"))
+                .ReturnsAsync(new AeResultStatus { PoNumber = " PO123456 " });
+
+            var result = await OrderService.TryPopulatePoNumberFromAggieEnterprise(order);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual("PO123456", order.PoNumber);
+            Mock.Get(EventService).Verify(a => a.OrderUpdated(
+                order,
+                "PO # automatically populated from Aggie Enterprise: PO123456"));
+            Mock.Get(OrderRepository).Verify(a => a.EnsurePersistent(order));
+        }
+
+        [TestMethod]
+        public async System.Threading.Tasks.Task TestTryPopulatePoNumberFromAggieEnterpriseDoesNothingWhenLookupHasNoPo()
+        {
+            var order = CreateValidEntities.Order(1);
+            order.StatusCode.Id = OrderStatusCode.Codes.Complete;
+            order.OrderType = new OrderType(OrderType.Types.AggieEnterprise);
+            order.ReferenceNumber = "184e9d20-f759-413e-8f42-06db62bf1e59";
+            order.PoNumber = null;
+
+            Mock.Get(AggieEnterpriseService)
+                .Setup(a => a.LookupOrderStatus(order.ReferenceNumber))
+                .ReturnsAsync(new AeResultStatus { PoNumber = " " });
+
+            var result = await OrderService.TryPopulatePoNumberFromAggieEnterprise(order);
+
+            Assert.IsFalse(result);
+            Assert.IsNull(order.PoNumber);
+            Mock.Get(EventService).Verify(
+                a => a.OrderUpdated(It.IsAny<Order>(), It.IsAny<string>()),
+                Times.Never());
+            Mock.Get(OrderRepository).Verify(a => a.EnsurePersistent(It.IsAny<Order>()), Times.Never());
+        }
+
+        [DataTestMethod]
+        [DataRow(OrderStatusCode.Codes.Purchaser, OrderType.Types.AggieEnterprise, "184e9d20-f759-413e-8f42-06db62bf1e59", null)]
+        [DataRow(OrderStatusCode.Codes.Complete, OrderType.Types.KfsDocument, "184e9d20-f759-413e-8f42-06db62bf1e59", null)]
+        [DataRow(OrderStatusCode.Codes.Complete, OrderType.Types.AggieEnterprise, " ", null)]
+        [DataRow(OrderStatusCode.Codes.Complete, OrderType.Types.AggieEnterprise, "184e9d20-f759-413e-8f42-06db62bf1e59", "PO123456")]
+        public async System.Threading.Tasks.Task TestTryPopulatePoNumberFromAggieEnterpriseOnlyLooksUpEligibleOrders(
+            string statusCode,
+            string orderType,
+            string referenceNumber,
+            string poNumber)
+        {
+            var order = CreateValidEntities.Order(1);
+            order.StatusCode.Id = statusCode;
+            order.OrderType = new OrderType(orderType);
+            order.ReferenceNumber = referenceNumber;
+            order.PoNumber = poNumber;
+
+            var result = await OrderService.TryPopulatePoNumberFromAggieEnterprise(order);
+
+            Assert.IsFalse(result);
+            Mock.Get(AggieEnterpriseService).Verify(
+                a => a.LookupOrderStatus(It.IsAny<string>()),
+                Times.Never());
+            Mock.Get(EventService).Verify(
+                a => a.OrderUpdated(It.IsAny<Order>(), It.IsAny<string>()),
+                Times.Never());
+            Mock.Get(OrderRepository).Verify(a => a.EnsurePersistent(It.IsAny<Order>()), Times.Never());
+        }
+
+        #endregion TryPopulatePoNumberFromAggieEnterprise Tests
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Order reviews can automatically retrieve and save available purchase order numbers from Aggie Enterprise after authorization.
  * Organization details display the parent organization, including a link and identifier when available.
  * Updated messaging explains that Aggie Enterprise orders uploaded from PrePurchasing can be edited.

* **Bug Fixes**
  * Orders without eligible details or an available purchase order number remain unchanged.

* **Updates**
  * Removed the Aggie Enterprise announcement from the home page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->